### PR TITLE
mpf saving / improvements

### DIFF
--- a/.github/workflows/dalib-build.yml
+++ b/.github/workflows/dalib-build.yml
@@ -30,4 +30,3 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --configuration Release --no-restore
-k

--- a/.github/workflows/dalib-build.yml
+++ b/.github/workflows/dalib-build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'eriscorp/dalib'
     runs-on: ubuntu-latest
     environment: deploy
     strategy:

--- a/DALib/DALib.csproj
+++ b/DALib/DALib.csproj
@@ -30,7 +30,6 @@
     <ItemGroup>
         <PackageReference Include="KGySoft.Drawing.SkiaSharp" Version="7.2.0"/>
         <PackageReference Include="SkiaSharp" Version="2.88.6"/>
-        <PackageReference Include="zlib.net" Version="1.0.4"/>
     </ItemGroup>
     <ItemGroup>
         <SupportedPlatform Include="Linux"/>

--- a/DALib/Data/MetaFile.cs
+++ b/DALib/Data/MetaFile.cs
@@ -11,10 +11,12 @@ namespace DALib.Data;
 
 public sealed class MetaFile : Collection<MetaFileEntry>, ISavable
 {
-    public MetaFile(Stream stream, bool leaveOpen = false)
+    public MetaFile() { }
+
+    private MetaFile(Stream stream)
     {
         var encoding = CodePagesEncodingProvider.Instance.GetEncoding(949)!;
-        using var reader = new BinaryReader(stream, encoding, leaveOpen);
+        using var reader = new BinaryReader(stream, encoding, true);
 
         var entryCount = reader.ReadUInt16(true);
 

--- a/DALib/Data/MetaFileEntry.cs
+++ b/DALib/Data/MetaFileEntry.cs
@@ -1,15 +1,10 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace DALib.Data;
 
-public sealed class MetaFileEntry
+public sealed class MetaFileEntry(string key, IEnumerable<string>? properties = null)
 {
-    public string Key { get; }
-    public List<string> Properties { get; }
-
-    internal MetaFileEntry(string key, IEnumerable<string> properties)
-    {
-        Key = key;
-        Properties = new List<string>(properties);
-    }
+    public string Key { get; } = key;
+    public List<string> Properties { get; } = properties?.ToList() ?? new List<string>();
 }

--- a/DALib/Definitions/Enums.cs
+++ b/DALib/Definitions/Enums.cs
@@ -40,3 +40,15 @@ public enum EfaBlendingType : byte
     /// </summary>
     NotSure = 3
 }
+
+public enum MpfHeaderType
+{
+    Unknown = -1,
+    None = 0
+}
+
+public enum MpfFormatType
+{
+    MultipleAttacks = -1,
+    SingleAttack = 0
+}

--- a/DALib/Drawing/ColorTableEntry.cs
+++ b/DALib/Drawing/ColorTableEntry.cs
@@ -4,6 +4,6 @@ namespace DALib.Drawing;
 
 public sealed class ColorTableEntry
 {
-    public byte ColorIndex { get; init; }
-    public required SKColor[] Colors { get; init; }
+    public byte ColorIndex { get; set; }
+    public required SKColor[] Colors { get; set; }
 }

--- a/DALib/Drawing/EfaFile.cs
+++ b/DALib/Drawing/EfaFile.cs
@@ -19,14 +19,14 @@ public sealed class EfaFile : Collection<EfaFrame>, ISavable
 {
     public EfaBlendingType BlendingType { get; set; }
     public int FrameIntervalMs { get; set; }
+    public int Unknown1 { get; set; }
     public byte[] Unknown2 { get; set; }
-    public int Unknown1 { get; }
 
-    private EfaFile()
+    public EfaFile()
     {
         Unknown1 = 0;
         BlendingType = EfaBlendingType.Luminance;
-        FrameIntervalMs = 10000;
+        FrameIntervalMs = 50;
         Unknown2 = new byte[51];
     }
 
@@ -135,8 +135,12 @@ public sealed class EfaFile : Collection<EfaFrame>, ISavable
     public static EfaFile FromImages(params SKImage[] orderedFrames)
     {
         var efaFile = new EfaFile();
-        var imageWidth = orderedFrames.Select(img => img.Width).Max();
-        var imageHeight = orderedFrames.Select(img => img.Height).Max();
+
+        var imageWidth = orderedFrames.Select(img => img.Width)
+                                      .Max();
+
+        var imageHeight = orderedFrames.Select(img => img.Height)
+                                       .Max();
 
         for (var i = 0; i < orderedFrames.Length; i++)
         {
@@ -157,7 +161,8 @@ public sealed class EfaFile : Collection<EfaFrame>, ISavable
                         writer.WriteRgb565Color(color);
                     }
 
-                rawBytes = writer.ToSpan().ToArray();
+                rawBytes = writer.ToSpan()
+                                 .ToArray();
             }
 
             efaFile.Add(
@@ -198,7 +203,8 @@ public sealed class EfaFile : Collection<EfaFrame>, ISavable
 
         decompressor.ReadAtLeast(decompressed, frame.RawSize);
 
-        decompressed[..frame.ByteCount].CopyTo(frame.Data);
+        decompressed[..frame.ByteCount]
+            .CopyTo(frame.Data);
 
         /*
         //Not sure what these numbers are

--- a/DALib/Drawing/EfaFile.cs
+++ b/DALib/Drawing/EfaFile.cs
@@ -136,11 +136,8 @@ public sealed class EfaFile : Collection<EfaFrame>, ISavable
     {
         var efaFile = new EfaFile();
 
-        var imageWidth = orderedFrames.Select(img => img.Width)
-                                      .Max();
-
-        var imageHeight = orderedFrames.Select(img => img.Height)
-                                       .Max();
+        var imageWidth = orderedFrames.Max(img => img.Width);
+        var imageHeight = orderedFrames.Max(img => img.Height);
 
         for (var i = 0; i < orderedFrames.Length; i++)
         {

--- a/DALib/Drawing/EfaFrame.cs
+++ b/DALib/Drawing/EfaFrame.cs
@@ -2,24 +2,24 @@
 
 public sealed class EfaFrame
 {
-    public int ByteCount { get; init; }
-    public int ByteWidth { get; init; }
-    public required byte[] Data { get; init; }
-    public short FrameHeight { get; init; }
-    public short FrameWidth { get; init; }
-    public short ImageHeight { get; init; }
-    public short ImageWidth { get; init; }
+    public int ByteCount { get; set; }
+    public int ByteWidth { get; set; }
+    public required byte[] Data { get; set; }
+    public short FrameHeight { get; set; }
+    public short FrameWidth { get; set; }
+    public short ImageHeight { get; set; }
+    public short ImageWidth { get; set; }
     public int Offset { get; set; }
-    public int OriginFlags { get; init; }
+    public int OriginFlags { get; set; }
     public short OriginX { get; set; }
     public short OriginY { get; set; }
-    public int Pad1Flags { get; init; }
-    public int Pad2Flags { get; init; }
-    public int RawSize { get; init; }
+    public int Pad1Flags { get; set; }
+    public int Pad2Flags { get; set; }
+    public int RawSize { get; set; }
     public int Size { get; set; }
-    public int Unknown1 { get; init; }
-    public int Unknown2 { get; init; }
-    public int Unknown3 { get; init; }
-    public int Unknown4 { get; init; }
-    public int Unknown5 { get; init; }
+    public int Unknown1 { get; set; }
+    public int Unknown2 { get; set; }
+    public int Unknown3 { get; set; }
+    public int Unknown4 { get; set; }
+    public int Unknown5 { get; set; }
 }

--- a/DALib/Drawing/EpfFile.cs
+++ b/DALib/Drawing/EpfFile.cs
@@ -14,11 +14,11 @@ namespace DALib.Drawing;
 
 public sealed class EpfFile : Collection<EpfFrame>, ISavable
 {
-    public short Height { get; }
-    public byte[] UnknownBytes { get; }
-    public short Width { get; }
+    public short Height { get; set; }
+    public byte[] UnknownBytes { get; set; }
+    public short Width { get; set; }
 
-    private EpfFile(short width, short height)
+    public EpfFile(short width, short height)
     {
         Height = height;
         Width = width;

--- a/DALib/Drawing/Graphics.cs
+++ b/DALib/Drawing/Graphics.cs
@@ -141,7 +141,7 @@ public class Graphics
         using var lfgCache = new SKImageCache<int>();
         using var rfgCache = new SKImageCache<int>();
 
-        //calculate width and height based on orthogonal view
+        //calculate width and height based on isometric view
         var width = map.Width * CONSTANTS.TILE_WIDTH;
         var height = map.Height * (CONSTANTS.TILE_HEIGHT + 1) + FOREGROUND_PADDING;
         using var bitmap = new SKBitmap(width, height);

--- a/DALib/Drawing/HpfFile.cs
+++ b/DALib/Drawing/HpfFile.cs
@@ -14,8 +14,8 @@ namespace DALib.Drawing;
 
 public sealed class HpfFile : ISavable
 {
-    public byte[] Data { get; }
-    public byte[] HeaderBytes { get; }
+    public byte[] Data { get; set; }
+    public byte[] HeaderBytes { get; set; }
     public int Height => Data.Length / CONSTANTS.HPF_TILE_WIDTH;
 
     public HpfFile(byte[] headerBytes, byte[] data)

--- a/DALib/Drawing/MpfFile.cs
+++ b/DALib/Drawing/MpfFile.cs
@@ -61,19 +61,15 @@ public class MpfFile : Collection<MpfFrame>, ISavable
                 var headerBytes = reader.ReadBytes(4);
 
                 //convert those bytes to a number
-                var num = BitConverter.ToInt32(UnknownHeaderBytes);
+                var num = BitConverter.ToInt32(headerBytes);
 
                 //if they equal "4", read 8 more bytes into the header
                 if (num == 4)
                 {
                     var moreBytes = reader.ReadBytes(8);
 
-                    Buffer.BlockCopy(
-                        moreBytes,
-                        0,
-                        headerBytes,
-                        4,
-                        8);
+                    headerBytes = headerBytes.Concat(moreBytes)
+                                             .ToArray();
                 }
 
                 UnknownHeaderBytes = headerBytes;
@@ -116,6 +112,7 @@ public class MpfFile : Collection<MpfFrame>, ISavable
                 break;
             default:
                 stream.Seek(-2, SeekOrigin.Current);
+
                 AttackFrameIndex = reader.ReadByte();
                 AttackFrameCount = reader.ReadByte();
                 StopFrameIndex = reader.ReadByte();

--- a/DALib/Drawing/MpfFile.cs
+++ b/DALib/Drawing/MpfFile.cs
@@ -132,8 +132,8 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
             var top = reader.ReadInt16();
             var right = reader.ReadInt16();
             var bottom = reader.ReadInt16();
-            var reflectionX = reader.ReadInt16();
-            var reflectionY = reader.ReadInt16();
+            var centerX = reader.ReadInt16();
+            var centerY = reader.ReadInt16();
             var startAddress = reader.ReadInt32();
 
             if ((left == -1) && (top == -1))
@@ -154,8 +154,8 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
                     Left = left,
                     Bottom = bottom,
                     Right = right,
-                    ReflectionX = reflectionX,
-                    ReflectionY = reflectionY,
+                    CenterX = centerX,
+                    CenterY = centerY,
                     StartAddress = startAddress,
                     Data = new byte[frameWidth * frameHeight]
                 });
@@ -235,8 +235,8 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
             writer.Write(frame.Top);
             writer.Write(frame.Right);
             writer.Write(frame.Bottom);
-            writer.Write(frame.ReflectionX);
-            writer.Write(frame.ReflectionY);
+            writer.Write(frame.CenterX);
+            writer.Write(frame.CenterY);
 
             frame.StartAddress = startAddress;
             startAddress += frame.Data.Length;

--- a/DALib/Drawing/MpfFile.cs
+++ b/DALib/Drawing/MpfFile.cs
@@ -1,43 +1,90 @@
 ﻿using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Text;
+using DALib.Abstractions;
 using DALib.Data;
+using DALib.Definitions;
 using DALib.Extensions;
+using DALib.Utility;
+using SkiaSharp;
 
 namespace DALib.Drawing;
 
-public class MpfFile : Collection<MpfFrame>
+public class MpfFile : Collection<MpfFrame>, ISavable
 {
-    public int Attack2FrameCount { get; init; }
-    public int Attack2StartIndex { get; init; }
-    public int Attack3FrameCount { get; init; }
-    public int Attack3StartIndex { get; init; }
-    public int AttackFrameCount { get; init; }
-    public int AttackFrameIndex { get; init; }
-    public int Height { get; init; }
-    public int PaletteNumber { get; init; }
-    public int StopFrameCount { get; init; }
-    public int StopFrameIndex { get; init; }
-    public int StopMotionFrameCount { get; init; }
-    public int StopMotionProbability { get; init; }
-    public byte[] UnknownBytes { get; init; }
-    public int WalkFrameCount { get; init; }
-    public int WalkFrameIndex { get; init; }
-    public int Width { get; init; }
+    public byte Attack2FrameCount { get; set; }
+    public byte Attack2StartIndex { get; set; }
+    public byte Attack3FrameCount { get; set; }
+    public byte Attack3StartIndex { get; set; }
+    public byte AttackFrameCount { get; set; }
+    public byte AttackFrameIndex { get; set; }
+    public MpfFormatType FormatType { get; set; }
+    public MpfHeaderType HeaderType { get; set; }
+    public short Height { get; set; }
+    public int PaletteNumber { get; set; }
+    public byte StopFrameCount { get; set; }
+    public byte StopFrameIndex { get; set; }
+    public byte StopMotionFrameCount { get; set; }
+    public byte StopMotionProbability { get; set; }
+    public byte[] UnknownHeaderBytes { get; set; }
+    public byte WalkFrameCount { get; set; }
+    public byte WalkFrameIndex { get; set; }
+    public short Width { get; set; }
+
+    public MpfFile(
+        MpfHeaderType headerType,
+        MpfFormatType formatType,
+        short width,
+        short height)
+    {
+        HeaderType = headerType;
+        FormatType = formatType;
+        UnknownHeaderBytes = HeaderType == MpfHeaderType.Unknown ? new byte[4] : Array.Empty<byte>();
+        Width = width;
+        Height = height;
+    }
 
     private MpfFile(Stream stream)
     {
-        using var reader = new BinaryReader(stream, Encoding.UTF8, true);
+        using var reader = new BinaryReader(stream, Encoding.Default, true);
 
-        if (reader.ReadInt32() == -1)
+        HeaderType = (MpfHeaderType)reader.ReadInt32();
+
+        switch (HeaderType)
         {
-            var unknown = reader.ReadInt32();
-            UnknownBytes = unknown == 4 ? reader.ReadBytes(8) : BitConverter.GetBytes(unknown);
-        } else
-        {
-            UnknownBytes = Array.Empty<byte>();
-            stream.Seek(-4, SeekOrigin.Current);
+            case MpfHeaderType.Unknown:
+                //read 4 bytes
+                var headerBytes = reader.ReadBytes(4);
+
+                //convert those bytes to a number
+                var num = BitConverter.ToInt32(UnknownHeaderBytes);
+
+                //if they equal "4", read 8 more bytes into the header
+                if (num == 4)
+                {
+                    var moreBytes = reader.ReadBytes(8);
+
+                    Buffer.BlockCopy(
+                        moreBytes,
+                        0,
+                        headerBytes,
+                        4,
+                        8);
+                }
+
+                UnknownHeaderBytes = headerBytes;
+
+                break;
+            default:
+                stream.Seek(-4, SeekOrigin.Current);
+
+                UnknownHeaderBytes = Array.Empty<byte>();
+
+                break;
         }
 
         var frameCount = reader.ReadByte();
@@ -50,30 +97,38 @@ public class MpfFile : Collection<MpfFrame>
         WalkFrameIndex = reader.ReadByte();
         WalkFrameCount = reader.ReadByte();
 
-        if (reader.ReadInt16() == -1)
+        FormatType = (MpfFormatType)reader.ReadInt16();
+
+        switch (FormatType)
         {
-            StopFrameIndex = reader.ReadByte();
-            StopFrameCount = reader.ReadByte();
-            StopMotionFrameCount = reader.ReadByte();
-            StopMotionProbability = reader.ReadByte();
-            AttackFrameIndex = reader.ReadByte();
-            AttackFrameCount = reader.ReadByte();
-            Attack2StartIndex = reader.ReadByte();
-            Attack2FrameCount = reader.ReadByte();
-            Attack3StartIndex = reader.ReadByte();
-            Attack3FrameCount = reader.ReadByte();
-        } else
-        {
-            stream.Seek(-2, SeekOrigin.Current);
-            AttackFrameIndex = reader.ReadByte();
-            AttackFrameCount = reader.ReadByte();
-            StopFrameIndex = reader.ReadByte();
-            StopFrameCount = reader.ReadByte();
-            StopMotionFrameCount = reader.ReadByte();
-            StopMotionProbability = reader.ReadByte();
+            case MpfFormatType.MultipleAttacks:
+                StopFrameIndex = reader.ReadByte();
+                StopFrameCount = reader.ReadByte();
+                StopMotionFrameCount = reader.ReadByte();
+                StopMotionProbability = reader.ReadByte();
+                AttackFrameIndex = reader.ReadByte();
+                AttackFrameCount = reader.ReadByte();
+                Attack2StartIndex = reader.ReadByte();
+                Attack2FrameCount = reader.ReadByte();
+                Attack3StartIndex = reader.ReadByte();
+                Attack3FrameCount = reader.ReadByte();
+
+                break;
+            default:
+                stream.Seek(-2, SeekOrigin.Current);
+                AttackFrameIndex = reader.ReadByte();
+                AttackFrameCount = reader.ReadByte();
+                StopFrameIndex = reader.ReadByte();
+                StopFrameCount = reader.ReadByte();
+                StopMotionFrameCount = reader.ReadByte();
+                StopMotionProbability = reader.ReadByte();
+
+                break;
         }
 
         var dataStart = stream.Length - dataLength;
+
+        using var dataSegment = stream.Slice(dataStart, dataLength);
 
         for (var i = 0; i < frameCount; ++i)
         {
@@ -96,19 +151,6 @@ public class MpfFile : Collection<MpfFrame>
             var frameWidth = right - left;
             var frameHeight = bottom - top;
 
-            byte[] data;
-
-            if ((frameWidth > 0) && (frameHeight > 0))
-            {
-                var position = stream.Position;
-                stream.Seek(dataStart + startAddress, SeekOrigin.Begin);
-                data = reader.ReadBytes(frameWidth * frameHeight);
-                stream.Seek(position, SeekOrigin.Begin);
-            } else
-            {
-                data = Array.Empty<byte>();
-            }
-
             Add(
                 new MpfFrame
                 {
@@ -118,12 +160,141 @@ public class MpfFile : Collection<MpfFrame>
                     Right = right,
                     XOffset = xOffset,
                     YOffset = yOffset,
-                    Data = data
+                    StartAddress = startAddress,
+                    Data = new byte[frameWidth * frameHeight]
                 });
+        }
+
+        foreach (var frame in this)
+        {
+            dataSegment.Seek(frame.StartAddress, SeekOrigin.Begin);
+
+            dataSegment.ReadExactly(frame.Data);
         }
     }
 
+    #region SaveTo
+    public void Save(string path)
+    {
+        using var stream = File.Open(
+            path.WithExtension(".mpf"),
+            new FileStreamOptions
+            {
+                Access = FileAccess.Write,
+                Mode = FileMode.Create,
+                Options = FileOptions.SequentialScan,
+                Share = FileShare.ReadWrite
+            });
+
+        Save(stream);
+    }
+
+    public void Save(Stream stream)
+    {
+        using var writer = new BinaryWriter(stream, Encoding.Default, true);
+
+        if (HeaderType == MpfHeaderType.Unknown)
+        {
+            writer.Write((int)HeaderType);
+            writer.Write(UnknownHeaderBytes);
+        }
+
+        var frameCount = (byte)(Count + 1);
+
+        writer.Write(frameCount);
+        writer.Write(Width);
+        writer.Write(Height);
+        writer.Write(this.Sum(frame => frame.Data.Length));
+        writer.Write(WalkFrameIndex);
+        writer.Write(WalkFrameCount);
+        writer.Write((short)FormatType);
+
+        if (FormatType == MpfFormatType.MultipleAttacks)
+        {
+            writer.Write((short)FormatType);
+            writer.Write(StopFrameIndex);
+            writer.Write(StopFrameCount);
+            writer.Write(StopMotionFrameCount);
+            writer.Write(StopMotionProbability);
+            writer.Write(AttackFrameIndex);
+            writer.Write(AttackFrameCount);
+            writer.Write(Attack2StartIndex);
+            writer.Write(Attack2FrameCount);
+            writer.Write(Attack3StartIndex);
+            writer.Write(Attack3FrameCount);
+        } else
+        {
+            writer.Write(AttackFrameIndex);
+            writer.Write(AttackFrameCount);
+            writer.Write(StopFrameIndex);
+            writer.Write(StopFrameCount);
+            writer.Write(StopMotionFrameCount);
+            writer.Write(StopMotionProbability);
+        }
+
+        //write palette number
+        writer.Write(-1);
+        writer.Write(new byte[8]);
+        writer.Write(PaletteNumber);
+
+        var startAddress = 0;
+
+        foreach (var frame in this)
+        {
+            writer.Write(frame.Left);
+            writer.Write(frame.Top);
+            writer.Write(frame.Right);
+            writer.Write(frame.Bottom);
+            writer.Write(BinaryPrimitives.ReverseEndianness(frame.XOffset));
+            writer.Write(BinaryPrimitives.ReverseEndianness(frame.YOffset));
+
+            frame.StartAddress = startAddress;
+            startAddress += frame.Data.Length;
+
+            writer.Write(frame.StartAddress);
+        }
+
+        foreach (var frame in this)
+            writer.Write(frame.Data);
+    }
+    #endregion
+
     #region LoadFrom
+    public static Palettized<MpfFile> FromImages(MpfFormatType formatType, IEnumerable<SKImage> orderedFrames)
+        => FromImages(formatType, orderedFrames.ToArray());
+
+    public static Palettized<MpfFile> FromImages(MpfFormatType formatType, params SKImage[] orderedFrames)
+    {
+        using var quantized = ImageProcessor.QuantizeMultiple(new QuantizerOptions(), orderedFrames);
+
+        (var images, var palette) = quantized;
+
+        var width = (short)images.Max(img => img.Width);
+        var height = (short)images.Max(img => img.Height);
+
+        var mpfFile = new MpfFile(
+            MpfHeaderType.None,
+            formatType,
+            width,
+            height);
+
+        foreach (var image in images)
+            mpfFile.Add(
+                new MpfFrame
+                {
+                    Right = (short)image.Width,
+                    Bottom = (short)image.Height,
+                    StartAddress = -1,
+                    Data = image.GetPalettizedPixelData(palette)
+                });
+
+        return new Palettized<MpfFile>
+        {
+            Entity = mpfFile,
+            Palette = palette
+        };
+    }
+
     public static MpfFile FromArchive(string fileName, DataArchive archive)
     {
         if (!archive.TryGetValue(fileName.WithExtension(".mpf"), out var entry))

--- a/DALib/Drawing/MpfFrame.cs
+++ b/DALib/Drawing/MpfFrame.cs
@@ -3,26 +3,28 @@
 public sealed class MpfFrame
 {
     public short Bottom { get; set; }
-    public required byte[] Data { get; set; }
-    public short Left { get; set; }
 
     /// <summary>
-    ///     This controls the X coordinate of the image in which the image will be flipped on when facing left or right
+    ///     The X coordinate of the image that lines up with the center of the draw area. The image will be reflected on this X
+    ///     coordinate when facing left or right
     /// </summary>
     /// <remarks>
     ///     This value is generally exactly(or very close to) ImageWidth / 2
     /// </remarks>
-    public short ReflectionX { get; set; }
+    public short CenterX { get; set; }
 
     /// <summary>
-    ///     This controls the Y coordinate of the image in which it might be reflected, but in practicality it represents the
-    ///     bottom of the image.
+    ///     The Y coordinate of the image that lines up with the center of the draw area. Generally, the bottom of the image
+    ///     sits on the center of the draw area
     /// </summary>
     /// <remarks>
     ///     This value is generally close to ImageHeight. Depending on how much space was left at the bottom of the frame vs
     ///     the total height of the image, you may need to subtract a small number of pixels (1-15)
     /// </remarks>
-    public short ReflectionY { get; set; }
+    public short CenterY { get; set; }
+
+    public required byte[] Data { get; set; }
+    public short Left { get; set; }
 
     public short Right { get; set; }
     public int StartAddress { get; set; }

--- a/DALib/Drawing/MpfFrame.cs
+++ b/DALib/Drawing/MpfFrame.cs
@@ -5,11 +5,28 @@ public sealed class MpfFrame
     public short Bottom { get; set; }
     public required byte[] Data { get; set; }
     public short Left { get; set; }
+
+    /// <summary>
+    ///     This controls the X coordinate of the image in which the image will be flipped on when facing left or right
+    /// </summary>
+    /// <remarks>
+    ///     This value is generally exactly(or very close to) ImageWidth / 2
+    /// </remarks>
+    public short ReflectionX { get; set; }
+
+    /// <summary>
+    ///     This controls the Y coordinate of the image in which it might be reflected, but in practicality it represents the
+    ///     bottom of the image.
+    /// </summary>
+    /// <remarks>
+    ///     This value is generally close to ImageHeight. Depending on how much space was left at the bottom of the frame vs
+    ///     the total height of the image, you may need to subtract a small number of pixels (1-15)
+    /// </remarks>
+    public short ReflectionY { get; set; }
+
     public short Right { get; set; }
     public int StartAddress { get; set; }
     public short Top { get; set; }
-    public short XOffset { get; set; }
-    public short YOffset { get; set; }
     public int Height => Bottom - Top;
     public int Width => Right - Left;
 }

--- a/DALib/Drawing/MpfFrame.cs
+++ b/DALib/Drawing/MpfFrame.cs
@@ -2,13 +2,14 @@
 
 public sealed class MpfFrame
 {
-    public int Bottom { get; init; }
-    public required byte[] Data { get; init; }
-    public int Left { get; init; }
-    public int Right { get; init; }
-    public int Top { get; init; }
-    public int XOffset { get; init; }
-    public int YOffset { get; init; }
+    public short Bottom { get; set; }
+    public required byte[] Data { get; set; }
+    public short Left { get; set; }
+    public short Right { get; set; }
+    public int StartAddress { get; set; }
+    public short Top { get; set; }
+    public short XOffset { get; set; }
+    public short YOffset { get; set; }
     public int Height => Bottom - Top;
     public int Width => Right - Left;
 }

--- a/DALib/Drawing/Palette.cs
+++ b/DALib/Drawing/Palette.cs
@@ -21,12 +21,12 @@ public sealed class Palette : Collection<SKColor>, ISavable
             Add(new SKColor(reader.ReadByte(), reader.ReadByte(), reader.ReadByte()));
     }
 
-    internal Palette()
+    public Palette()
         : base(
             Enumerable.Repeat(SKColor.Empty, CONSTANTS.COLORS_PER_PALETTE)
                       .ToList()) { }
 
-    internal Palette(IEnumerable<SKColor> colors)
+    public Palette(IEnumerable<SKColor> colors)
         : this()
     {
         var index = 0;

--- a/DALib/Drawing/PaletteTable.cs
+++ b/DALib/Drawing/PaletteTable.cs
@@ -20,7 +20,7 @@ public sealed class PaletteTable : ISavable
     private readonly Dictionary<int, int> Entries = new();
     private readonly Dictionary<int, int> Overrides = new();
 
-    private PaletteTable() { }
+    public PaletteTable() { }
 
     private PaletteTable(Stream stream)
     {
@@ -77,6 +77,12 @@ public sealed class PaletteTable : ISavable
             Entries[kvp.Key] = kvp.Value;
     }
 
+    public void Remove(int id)
+    {
+        Overrides.Remove(id);
+        Entries.Remove(id);
+    }
+
     #region SaveTo
     public void Save(string path)
     {
@@ -105,7 +111,9 @@ public sealed class PaletteTable : ISavable
 
         foreach (var set in orderedEntries.GroupBy(kvp => kvp.Value))
         {
-            var orderedKeys = set.Select(kvp => kvp.Key).Order().ToArray();
+            var orderedKeys = set.Select(kvp => kvp.Key)
+                                 .Order()
+                                 .ToArray();
             var ranges = new List<Range>();
 
             //extract ranges of consecutive keys for the same palette

--- a/DALib/Drawing/SpfFile.cs
+++ b/DALib/Drawing/SpfFile.cs
@@ -15,13 +15,13 @@ namespace DALib.Drawing;
 
 public sealed class SpfFile : Collection<SpfFrame>, ISavable
 {
-    public uint ColorFormat { get; }
-    public Palette PrimaryColors { get; }
-    public Palette SecondaryColors { get; }
-    public uint Unknown1 { get; }
-    public uint Unknown2 { get; }
+    public uint ColorFormat { get; set; }
+    public Palette PrimaryColors { get; set; }
+    public Palette SecondaryColors { get; set; }
+    public uint Unknown1 { get; set; }
+    public uint Unknown2 { get; set; }
 
-    private SpfFile(Palette primaryColors, Palette secondaryColors)
+    public SpfFile(Palette primaryColors, Palette secondaryColors)
     {
         PrimaryColors = primaryColors;
         SecondaryColors = secondaryColors;

--- a/DALib/Drawing/SpfFrame.cs
+++ b/DALib/Drawing/SpfFrame.cs
@@ -2,15 +2,15 @@
 
 public sealed class SpfFrame
 {
-    public uint ByteCount { get; init; }
-    public uint ByteWidth { get; init; }
-    public required byte[] Data { get; init; }
-    public ushort PadHeight { get; init; }
-    public ushort PadWidth { get; init; }
-    public ushort PixelHeight { get; init; }
-    public ushort PixelWidth { get; init; }
-    public uint Reserved { get; init; }
-    public uint SemiByteCount { get; init; }
+    public uint ByteCount { get; set; }
+    public uint ByteWidth { get; set; }
+    public required byte[] Data { get; set; }
+    public ushort PadHeight { get; set; }
+    public ushort PadWidth { get; set; }
+    public ushort PixelHeight { get; set; }
+    public ushort PixelWidth { get; set; }
+    public uint Reserved { get; set; }
+    public uint SemiByteCount { get; set; }
     public uint StartAddress { get; set; }
     public static uint Unknown => 0xCCCCCCCC; // Every SPF has this value associated with it
 }

--- a/DALib/Drawing/TileAnimationTable.cs
+++ b/DALib/Drawing/TileAnimationTable.cs
@@ -12,6 +12,8 @@ public class TileAnimationTable : ISavable
 {
     private readonly Dictionary<int, TileAnimationEntry> Entries = new();
 
+    public TileAnimationTable() { }
+
     private TileAnimationTable(Stream stream)
     {
         using var reader = new StreamReader(stream, Encoding.Default, leaveOpen: true);
@@ -28,7 +30,8 @@ public class TileAnimationTable : ISavable
 
             for (var i = 0; i < split.Length; ++i)
             {
-                var valueStr = split[i].Trim();
+                var valueStr = split[i]
+                    .Trim();
 
                 if (!ushort.TryParse(valueStr, out var value))
                     continue;

--- a/DALib/Drawing/Tileset.cs
+++ b/DALib/Drawing/Tileset.cs
@@ -14,7 +14,7 @@ namespace DALib.Drawing;
 
 public sealed class Tileset : Collection<Tile>, ISavable
 {
-    private Tileset() { }
+    public Tileset() { }
 
     private Tileset(Stream stream)
     {

--- a/DALib/Extensions/DictionaryExtensions.cs
+++ b/DALib/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Linq;
+using DALib.Drawing;
+
+namespace DALib.Extensions;
+
+public static class DictionaryExtensions
+{
+    public static int GetNextPaletteId(this Dictionary<int, Palette> palettes) => palettes.Keys.Max() + 1;
+}

--- a/DALib/IO/StreamSegment.cs
+++ b/DALib/IO/StreamSegment.cs
@@ -72,7 +72,7 @@ public class StreamSegment : Stream
     /// <inheritdoc />
     public override long Seek(long offset, SeekOrigin origin)
     {
-        if ((offset > Length) || (offset < 0))
+        if ((offset > Length) || ((origin == SeekOrigin.Begin) && (offset < 0)))
             throw new ArgumentOutOfRangeException(nameof(offset), offset, null);
 
         return origin switch


### PR DESCRIPTION
- mpf saving
- mpf from images
- mpf readability refactor
- removed unused zlib library
- update github workflow to only run on upstream repo
- remove aberrant character from git workflow
- fixed a bug in StreamSegment when seeking to negative offsets on current
- change most classes non-stream constructor to public
- changed most properties to be settable
- added support for the newest non-unity dat archives (read only)
- mpf offsetX and offsetY renamed to centerX and centerY