### PR TITLE
optimization

### DIFF
--- a/DALib/Abstractions/ISavable.cs
+++ b/DALib/Abstractions/ISavable.cs
@@ -10,12 +10,16 @@ public interface ISavable
     /// <summary>
     ///     Saves the object to the specified path
     /// </summary>
-    /// <param name="path">The path to save the object to</param>
+    /// <param name="path">
+    ///     The path to save the object to
+    /// </param>
     void Save(string path);
 
     /// <summary>
     ///     Writes the object to the specified stream
     /// </summary>
-    /// <param name="stream">The stream to write the object to</param>
+    /// <param name="stream">
+    ///     The stream to write the object to
+    /// </param>
     void Save(Stream stream);
 }

--- a/DALib/Cryptography/CRC16.cs
+++ b/DALib/Cryptography/CRC16.cs
@@ -268,15 +268,23 @@ public static class CRC16
     /// <summary>
     ///     Calculates the 16bit checksum of the specified buffer
     /// </summary>
-    /// <param name="buffer">The buffer to calculate the checksum of</param>
+    /// <param name="buffer">
+    ///     The buffer to calculate the checksum of
+    /// </param>
     public static ushort Calculate(byte[] buffer) => Calculate(buffer, 0, buffer.Length);
 
     /// <summary>
     ///     Calculates the 16bit checksum of the specified buffer
     /// </summary>
-    /// <param name="buffer">The buffer to calculate the checksum of</param>
-    /// <param name="offset">The offset within the buffer to start at</param>
-    /// <param name="count">The number of bytes within the buffer to calculate for</param>
+    /// <param name="buffer">
+    ///     The buffer to calculate the checksum of
+    /// </param>
+    /// <param name="offset">
+    ///     The offset within the buffer to start at
+    /// </param>
+    /// <param name="count">
+    ///     The number of bytes within the buffer to calculate for
+    /// </param>
     public static ushort Calculate(byte[] buffer, int offset, int count)
     {
         ushort result = 0;

--- a/DALib/Cryptography/CRC32.cs
+++ b/DALib/Cryptography/CRC32.cs
@@ -268,15 +268,23 @@ public static class CRC32
     /// <summary>
     ///     Calculates the 32bit checksum of the specified buffer
     /// </summary>
-    /// <param name="buffer">The buffer to calculate the checksum of</param>
+    /// <param name="buffer">
+    ///     The buffer to calculate the checksum of
+    /// </param>
     public static uint Calculate(byte[] buffer) => Calculate(buffer, 0, buffer.Length);
 
     /// <summary>
     ///     Calculates the 32bit checksum of the specified buffer
     /// </summary>
-    /// <param name="buffer">The buffer to calculate the checksum of</param>
-    /// <param name="offset">The offset within the buffer to start at</param>
-    /// <param name="count">The number of bytes within the buffer to calculate for</param>
+    /// <param name="buffer">
+    ///     The buffer to calculate the checksum of
+    /// </param>
+    /// <param name="offset">
+    ///     The offset within the buffer to start at
+    /// </param>
+    /// <param name="count">
+    ///     The number of bytes within the buffer to calculate for
+    /// </param>
     public static uint Calculate(byte[] buffer, int offset, int count)
     {
         var result = 0xFFFFFFFF;

--- a/DALib/Cryptography/PacketCryptoProvider.cs
+++ b/DALib/Cryptography/PacketCryptoProvider.cs
@@ -30,9 +30,15 @@ public class PacketCryptoProvider
     /// <summary>
     ///     Gets or sets the Keystream property, which represents the keystream as a string.
     /// </summary>
-    /// <value>The keystream as a string.</value>
-    /// <exception cref="ArgumentNullException">Thrown if the value is null.</exception>
-    /// <exception cref="Exception">Thrown if the value length is not equal to KEYSTREAM_LENGTH.</exception>
+    /// <value>
+    ///     The keystream as a string.
+    /// </value>
+    /// <exception cref="ArgumentNullException">
+    ///     Thrown if the value is null.
+    /// </exception>
+    /// <exception cref="Exception">
+    ///     Thrown if the value length is not equal to KEYSTREAM_LENGTH.
+    /// </exception>
     public string Keystream
     {
         get => Encoding.ASCII.GetString(_keystream1);
@@ -74,8 +80,8 @@ public class PacketCryptoProvider
     }
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="PacketCryptoProvider" /> class.
-    ///     Uses the default seed and keystream values.
+    ///     Initializes a new instance of the <see cref="PacketCryptoProvider" /> class. Uses the default seed and keystream
+    ///     values.
     /// </summary>
     public PacketCryptoProvider()
         : this(DEFAULT_SEED, DEFAULT_KEYSTREAM)
@@ -117,10 +123,18 @@ public class PacketCryptoProvider
     /// <summary>
     ///     Decrypts client data using the specified parameters.
     /// </summary>
-    /// <param name="data">The byte array containing the encrypted client data.</param>
-    /// <param name="offset">The starting index within the byte array.</param>
-    /// <param name="count">The number of bytes to be decrypted.</param>
-    /// <param name="useKeystream2">Specifies whether to use keystream 2 for decryption.</param>
+    /// <param name="data">
+    ///     The byte array containing the encrypted client data.
+    /// </param>
+    /// <param name="offset">
+    ///     The starting index within the byte array.
+    /// </param>
+    /// <param name="count">
+    ///     The number of bytes to be decrypted.
+    /// </param>
+    /// <param name="useKeystream2">
+    ///     Specifies whether to use keystream 2 for decryption.
+    /// </param>
     /// <returns>
     ///     The decrypted client data as a byte array.
     /// </returns>
@@ -184,11 +198,21 @@ public class PacketCryptoProvider
     /// <summary>
     ///     Decrypts server data.
     /// </summary>
-    /// <param name="data">The data to decrypt.</param>
-    /// <param name="offset">The starting offset in the data.</param>
-    /// <param name="count">The number of bytes to decrypt.</param>
-    /// <param name="useKeystream2">Flag to indicate if keystream2 should be used for transformation.</param>
-    /// <returns>The decrypted server data as a byte array.</returns>
+    /// <param name="data">
+    ///     The data to decrypt.
+    /// </param>
+    /// <param name="offset">
+    ///     The starting offset in the data.
+    /// </param>
+    /// <param name="count">
+    ///     The number of bytes to decrypt.
+    /// </param>
+    /// <param name="useKeystream2">
+    ///     Flag to indicate if keystream2 should be used for transformation.
+    /// </param>
+    /// <returns>
+    ///     The decrypted server data as a byte array.
+    /// </returns>
     public byte[] DecryptServerData(
         byte[] data,
         int offset,
@@ -240,12 +264,24 @@ public class PacketCryptoProvider
     /// <summary>
     ///     Encrypts the provided client data using the specified parameters.
     /// </summary>
-    /// <param name="data">The data to encrypt.</param>
-    /// <param name="offset">The starting index in the data array from which to begin encryption.</param>
-    /// <param name="count">The number of bytes to encrypt.</param>
-    /// <param name="sequence">The sequence value to use during encryption.</param>
-    /// <param name="useKeystream2">Determines whether to use Keystream2 during encryption.</param>
-    /// <returns>The encrypted client data.</returns>
+    /// <param name="data">
+    ///     The data to encrypt.
+    /// </param>
+    /// <param name="offset">
+    ///     The starting index in the data array from which to begin encryption.
+    /// </param>
+    /// <param name="count">
+    ///     The number of bytes to encrypt.
+    /// </param>
+    /// <param name="sequence">
+    ///     The sequence value to use during encryption.
+    /// </param>
+    /// <param name="useKeystream2">
+    ///     Determines whether to use Keystream2 during encryption.
+    /// </param>
+    /// <returns>
+    ///     The encrypted client data.
+    /// </returns>
     public byte[] EncryptClientData(
         byte[] data,
         int offset,
@@ -319,12 +355,24 @@ public class PacketCryptoProvider
     /// <summary>
     ///     Encrypts server data using the specified parameters.
     /// </summary>
-    /// <param name="data">The data to be encrypted.</param>
-    /// <param name="offset">The starting offset within the data array.</param>
-    /// <param name="count">The number of bytes to be encrypted.</param>
-    /// <param name="sequence">The sequence number used for encryption.</param>
-    /// <param name="useKeystream2">Determines whether to use the second keystream for encryption.</param>
-    /// <returns>The encrypted server data as a byte array.</returns>
+    /// <param name="data">
+    ///     The data to be encrypted.
+    /// </param>
+    /// <param name="offset">
+    ///     The starting offset within the data array.
+    /// </param>
+    /// <param name="count">
+    ///     The number of bytes to be encrypted.
+    /// </param>
+    /// <param name="sequence">
+    ///     The sequence number used for encryption.
+    /// </param>
+    /// <param name="useKeystream2">
+    ///     Determines whether to use the second keystream for encryption.
+    /// </param>
+    /// <returns>
+    ///     The encrypted server data as a byte array.
+    /// </returns>
     public byte[] EncryptServerData(
         byte[] data,
         int offset,
@@ -393,7 +441,9 @@ public class PacketCryptoProvider
     /// <summary>
     ///     Generates a keystream table based on the given name.
     /// </summary>
-    /// <param name="name">The name to generate the keystream table from.</param>
+    /// <param name="name">
+    ///     The name to generate the keystream table from.
+    /// </param>
     public void GenerateKeystream2Table(string name)
     {
         var table = GetMd5String(GetMd5String(name));

--- a/DALib/Data/DataArchive.cs
+++ b/DALib/Data/DataArchive.cs
@@ -61,9 +61,15 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// <summary>
     ///     Returns a collection of data archive entries that match the given pattern and extension.
     /// </summary>
-    /// <param name="pattern">The pattern to match the entry name against.</param>
-    /// <param name="extension">The extension to match the entry name against.</param>
-    /// <returns>A collection of <see cref="DataArchiveEntry" /> objects that match the pattern and extension.</returns>
+    /// <param name="pattern">
+    ///     The pattern to match the entry name against.
+    /// </param>
+    /// <param name="extension">
+    ///     The extension to match the entry name against.
+    /// </param>
+    /// <returns>
+    ///     A collection of <see cref="DataArchiveEntry" /> objects that match the pattern and extension.
+    /// </returns>
     public IEnumerable<DataArchiveEntry> GetEntries(string pattern, string extension)
     {
         foreach (var entry in this)
@@ -81,7 +87,9 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// <summary>
     ///     Retrieves all entries with a specified extension.
     /// </summary>
-    /// <param name="extension">The extension to filter the entries with.</param>
+    /// <param name="extension">
+    ///     The extension to filter the entries with.
+    /// </param>
     /// <returns>
     ///     An <see cref="IEnumerable{T}" /> of <see cref="DataArchiveEntry" /> containing all entries with the specified
     ///     extension.
@@ -106,9 +114,15 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     ///     Patches the DataArchive by appending a new entry that replaces an existing entry with the same name, or adds a new
     ///     entry if no existing entry has the same name.
     /// </summary>
-    /// <param name="entryName">The name of the entry to be patched.</param>
-    /// <param name="item">The item to be patched.</param>
-    /// <exception cref="InvalidOperationException">Thrown if the DataArchive is not in memory.</exception>
+    /// <param name="entryName">
+    ///     The name of the entry to be patched.
+    /// </param>
+    /// <param name="item">
+    ///     The item to be patched.
+    /// </param>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown if the DataArchive is not in memory.
+    /// </exception>
     public void Patch(string entryName, ISavable item)
     {
         ThrowIfDisposed();
@@ -141,10 +155,18 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
 
     #region SaveTo
     /// <inheritdoc />
-    /// <exception cref="ObjectDisposedException">Thrown if the object is already disposed.</exception>
-    /// <exception cref="ArgumentNullException">Thrown if the path is null.</exception>
-    /// <exception cref="ArgumentException">Thrown if the path is empty or contains invalid characters.</exception>
-    /// <exception cref="PathTooLongException">Thrown if the path exceeds the maximum length allowed.</exception>
+    /// <exception cref="ObjectDisposedException">
+    ///     Thrown if the object is already disposed.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    ///     Thrown if the path is null.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///     Thrown if the path is empty or contains invalid characters.
+    /// </exception>
+    /// <exception cref="PathTooLongException">
+    ///     Thrown if the path exceeds the maximum length allowed.
+    /// </exception>
     public void Save(string path)
     {
         ThrowIfDisposed();
@@ -164,8 +186,12 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     }
 
     /// <inheritdoc />
-    /// <exception cref="ObjectDisposedException">Thrown if the object has been disposed.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if an entry name is too long (must be 13 characters or less).</exception>
+    /// <exception cref="ObjectDisposedException">
+    ///     Thrown if the object has been disposed.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown if an entry name is too long (must be 13 characters or less).
+    /// </exception>
     public void Save(Stream stream)
     {
         ThrowIfDisposed();
@@ -217,8 +243,12 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// <summary>
     ///     Extracts the contents of the current archive to the specified directory.
     /// </summary>
-    /// <param name="dir">The directory to which the contents will be extracted.</param>
-    /// <exception cref="InvalidOperationException">Thrown when the archive is already disposed.</exception>
+    /// <param name="dir">
+    ///     The directory to which the contents will be extracted.
+    /// </param>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the archive is already disposed.
+    /// </exception>
     public void ExtractTo(string dir)
     {
         ThrowIfDisposed();
@@ -239,8 +269,12 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// <summary>
     ///     Loads a DataArchive from a directory that contains already extracted entries
     /// </summary>
-    /// <param name="dir">The directory path.</param>
-    /// <returns>A new DataArchive object.</returns>
+    /// <param name="dir">
+    ///     The directory path.
+    /// </param>
+    /// <returns>
+    ///     A new DataArchive object.
+    /// </returns>
     public static DataArchive FromDirectory(string dir)
     {
         //create a new in-memory archive
@@ -286,13 +320,18 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// <summary>
     ///     Loads a DataArchive from the specified path
     /// </summary>
-    /// <param name="path">The path to the file to create the DataArchive from.</param>
-    /// <param name="cacheArchive">
-    ///     Indicates whether to cache the archive in memory or read from file using pointers. Default
-    ///     is false.
+    /// <param name="path">
+    ///     The path to the file to create the DataArchive from.
     /// </param>
-    /// <param name="newformat">Indicates whether to use the new format when reading the archive. Default is false.</param>
-    /// <returns>A new instance of the DataArchive class.</returns>
+    /// <param name="cacheArchive">
+    ///     Indicates whether to cache the archive in memory or read from file using pointers. Default is false.
+    /// </param>
+    /// <param name="newformat">
+    ///     Indicates whether to use the new format when reading the archive. Default is false.
+    /// </param>
+    /// <returns>
+    ///     A new instance of the DataArchive class.
+    /// </returns>
     public static DataArchive FromFile(string path, bool cacheArchive = false, bool newformat = false)
     {
         //if we don't want to cache the archive

--- a/DALib/Data/DataArchive.cs
+++ b/DALib/Data/DataArchive.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Text;
 using DALib.Abstractions;
@@ -13,17 +14,24 @@ namespace DALib.Data;
 /// <summary>
 ///     Represents a DarkAges data archive that can be used for storing and manipulating data entries.
 /// </summary>
-public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(StringComparer.OrdinalIgnoreCase), ISavable, IDisposable
+public class DataArchive : KeyedCollection<string, DataArchiveEntry>, ISavable, IDisposable
 {
     private bool IsDisposed;
-    internal Stream? DataStream { get; set; }
 
-    private DataArchive(Stream stream, bool newFormat = false)
-        : this()
+    /// <summary>
+    ///     The base stream of the archive
+    /// </summary>
+    protected Stream BaseStream { get; set; }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DataArchive" /> class.
+    /// </summary>
+    protected DataArchive(Stream stream, bool newFormat = false)
+        : base(StringComparer.OrdinalIgnoreCase)
     {
-        DataStream = stream;
+        BaseStream = stream;
 
-        using var reader = new BinaryReader(stream, Encoding.Default, true);
+        using var reader = new BinaryReader(BaseStream, Encoding.Default, true);
 
         var expectedNumberOfEntries = reader.ReadInt32() - 1;
 
@@ -58,6 +66,39 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
         }
     }
 
+    /// <inheritdoc />
+    public virtual void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        BaseStream.Dispose();
+        IsDisposed = true;
+    }
+
+    /// <summary>
+    ///     Extracts the contents of the current archive to the specified directory.
+    /// </summary>
+    /// <param name="dir">
+    ///     The directory to which the contents will be extracted.
+    /// </param>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the archive is already disposed.
+    /// </exception>
+    public virtual void ExtractTo(string dir)
+    {
+        ThrowIfDisposed();
+
+        foreach (var entry in this)
+        {
+            var path = Path.Combine(dir, entry.EntryName);
+
+            using var stream = File.Create(path);
+            using var segment = GetEntryStream(entry);
+
+            segment.CopyTo(stream);
+        }
+    }
+
     /// <summary>
     ///     Returns a collection of data archive entries that match the given pattern and extension.
     /// </summary>
@@ -70,7 +111,7 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// <returns>
     ///     A collection of <see cref="DataArchiveEntry" /> objects that match the pattern and extension.
     /// </returns>
-    public IEnumerable<DataArchiveEntry> GetEntries(string pattern, string extension)
+    public virtual IEnumerable<DataArchiveEntry> GetEntries(string pattern, string extension)
     {
         foreach (var entry in this)
         {
@@ -94,7 +135,7 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     ///     An <see cref="IEnumerable{T}" /> of <see cref="DataArchiveEntry" /> containing all entries with the specified
     ///     extension.
     /// </returns>
-    public IEnumerable<DataArchiveEntry> GetEntries(string extension)
+    public virtual IEnumerable<DataArchiveEntry> GetEntries(string extension)
     {
         foreach (var entry in this)
         {
@@ -105,10 +146,13 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
         }
     }
 
-    #region KeyedCollection implementation
+    /// <summary>
+    ///     Gets a stream that contains the data for the specified entry.
+    /// </summary>
+    public virtual Stream GetEntryStream(DataArchiveEntry entry) => BaseStream.Slice(entry.Address, entry.FileSize);
+
     /// <inheritdoc />
     protected override string GetKeyForItem(DataArchiveEntry item) => item.EntryName;
-    #endregion
 
     /// <summary>
     ///     Patches the DataArchive by appending a new entry that replaces an existing entry with the same name, or adds a new
@@ -123,35 +167,32 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// <exception cref="InvalidOperationException">
     ///     Thrown if the DataArchive is not in memory.
     /// </exception>
-    public void Patch(string entryName, ISavable item)
+    public virtual void Patch(string entryName, ISavable item)
     {
         ThrowIfDisposed();
-
-        if (DataStream is not MemoryStream)
-            throw new InvalidOperationException("DataArchive must be in memory to patch (use cacheArchive=true)");
 
         //if an entry exists with the same name, remove it
         Remove(entryName);
 
-        using var buffer = new MemoryStream();
-        item.Save(buffer);
+        BaseStream.Seek(0, SeekOrigin.End);
+        var address = (int)BaseStream.Length;
+
+        item.Save(BaseStream);
+
+        var length = (int)BaseStream.Length - address;
 
         //create a new entry (this entry will be appended to the end of the archive)
         var entry = new DataArchiveEntry(
             this,
             entryName,
-            (int)DataStream!.Length,
-            (int)buffer.Length);
-
-        //seek to the end of the archive and append the new entry
-        DataStream!.Seek(0, SeekOrigin.End);
-        buffer.Seek(0, SeekOrigin.Begin);
-
-        buffer.CopyTo(DataStream);
+            address,
+            length);
 
         //add entry to archive
         Add(entry);
     }
+
+    internal void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(IsDisposed, this);
 
     #region SaveTo
     /// <inheritdoc />
@@ -167,10 +208,14 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// <exception cref="PathTooLongException">
     ///     Thrown if the path exceeds the maximum length allowed.
     /// </exception>
-    public void Save(string path)
+    public virtual void Save(string path)
     {
         ThrowIfDisposed();
 
+        using var buffer = new MemoryStream();
+        Save(buffer);
+
+        // ReSharper disable once ConvertToUsingDeclaration
         using var stream = File.Open(
             path.WithExtension(".dat"),
             new FileStreamOptions
@@ -182,7 +227,8 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
                 BufferSize = 81920
             });
 
-        Save(stream);
+        buffer.Seek(0, SeekOrigin.Begin);
+        buffer.CopyTo(stream);
     }
 
     /// <inheritdoc />
@@ -192,7 +238,7 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// <exception cref="InvalidOperationException">
     ///     Thrown if an entry name is too long (must be 13 characters or less).
     /// </exception>
-    public void Save(Stream stream)
+    public virtual void Save(Stream stream)
     {
         ThrowIfDisposed();
 
@@ -239,35 +285,12 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
             segment.CopyTo(stream);
         }
     }
-
-    /// <summary>
-    ///     Extracts the contents of the current archive to the specified directory.
-    /// </summary>
-    /// <param name="dir">
-    ///     The directory to which the contents will be extracted.
-    /// </param>
-    /// <exception cref="InvalidOperationException">
-    ///     Thrown when the archive is already disposed.
-    /// </exception>
-    public void ExtractTo(string dir)
-    {
-        ThrowIfDisposed();
-
-        foreach (var entry in this)
-        {
-            var path = Path.Combine(dir, entry.EntryName);
-
-            using var stream = File.Create(path);
-            using var segment = entry.ToStreamSegment();
-
-            segment.CopyTo(stream);
-        }
-    }
     #endregion
 
     #region LoadFrom
     /// <summary>
-    ///     Loads a DataArchive from a directory that contains already extracted entries
+    ///     Loads a DataArchive from a directory that contains already extracted entries. The resulting archive is not memory
+    ///     mapped, and will be fully loaded into memory
     /// </summary>
     /// <param name="dir">
     ///     The directory path.
@@ -277,9 +300,10 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// </returns>
     public static DataArchive FromDirectory(string dir)
     {
+        var buffer = new MemoryStream();
+
         //create a new in-memory archive
-        var archive = new DataArchive();
-        archive.DataStream = new MemoryStream();
+        var archive = new DataArchive(buffer);
 
         var address = 0;
 
@@ -298,7 +322,7 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
                     BufferSize = 8192
                 });
 
-            stream.CopyTo(archive.DataStream);
+            stream.CopyTo(buffer);
 
             var entryName = Path.GetFileName(file);
             var length = (int)stream.Length;
@@ -323,8 +347,10 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// <param name="path">
     ///     The path to the file to create the DataArchive from.
     /// </param>
-    /// <param name="cacheArchive">
-    ///     Indicates whether to cache the archive in memory or read from file using pointers. Default is false.
+    /// <param name="memoryMapped">
+    ///     Indicates whether to open the archive using a <see cref="MemoryMappedFile" />. An archive opened this way is not
+    ///     fully loaded into memory, and can not be patched or saved. Using a memory mapped file is more performant for reads,
+    ///     and uses less memory. Default is true, set it to false if you want to patch or save the archive.
     /// </param>
     /// <param name="newformat">
     ///     Indicates whether to use the new format when reading the archive. Default is false.
@@ -332,55 +358,51 @@ public sealed class DataArchive() : KeyedCollection<string, DataArchiveEntry>(St
     /// <returns>
     ///     A new instance of the DataArchive class.
     /// </returns>
-    public static DataArchive FromFile(string path, bool cacheArchive = false, bool newformat = false)
+    public static DataArchive FromFile(string path, bool memoryMapped = true, bool newformat = false)
     {
-        //if we don't want to cache the archive
-        //return an archive that reads using pointers from an open file handle
-        if (!cacheArchive)
-            return new DataArchive(
-                File.Open(
-                    path.WithExtension(".dat"),
-                    new FileStreamOptions
-                    {
-                        Access = FileAccess.Read,
-                        Mode = FileMode.Open,
-                        Options = FileOptions.RandomAccess,
-                        Share = FileShare.ReadWrite,
-                        BufferSize = 8192
-                    }),
-                newformat);
+        if (memoryMapped)
+        {
+            //use a memory mapped file
+            var fs = File.Open(
+                path.WithExtension(".dat"),
+                new FileStreamOptions
+                {
+                    Access = FileAccess.Read,
+                    Mode = FileMode.Open,
+                    Options = FileOptions.RandomAccess,
+                    Share = FileShare.ReadWrite,
+                    BufferSize = 8192
+                });
 
-        //if we do want to cache the archive
-        //copy the whole file into a memorystream and use that
-        //pointers will still be used, but the data will be cached in memory
-        using var stream = File.Open(
+            var mappedFile = MemoryMappedFile.CreateFromFile(
+                fs,
+                null,
+                0,
+                MemoryMappedFileAccess.Read,
+                HandleInheritability.None,
+                false);
+
+            return new MemoryMappedDataArchive(mappedFile, newformat);
+        }
+
+        //load the file into memory
+        using var fileStream = File.Open(
             path.WithExtension(".dat"),
             new FileStreamOptions
             {
                 Access = FileAccess.Read,
                 Mode = FileMode.Open,
-                Options = FileOptions.SequentialScan,
+                Options = FileOptions.RandomAccess,
                 Share = FileShare.ReadWrite,
-                BufferSize = 81920
+                BufferSize = 8192
             });
 
-        var memory = new MemoryStream((int)stream.Length);
-        stream.CopyTo(memory);
+        var buffer = new MemoryStream((int)fileStream.Length);
+        fileStream.CopyTo(buffer);
 
-        memory.Seek(0, SeekOrigin.Begin);
+        buffer.Seek(0, SeekOrigin.Begin);
 
-        return new DataArchive(memory, newformat);
+        return new DataArchive(buffer, newformat);
     }
-    #endregion
-
-    #region IDisposable implementation
-    /// <inheritdoc />
-    public void Dispose()
-    {
-        DataStream?.Dispose();
-        IsDisposed = true;
-    }
-
-    internal void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(IsDisposed, this);
     #endregion
 }

--- a/DALib/Data/DataArchiveEntry.cs
+++ b/DALib/Data/DataArchiveEntry.cs
@@ -32,9 +32,15 @@ public sealed class DataArchiveEntry(
     ///     Initializes a new instance of the <see cref="DataArchiveEntry" /> class with it's containing archive, entry name,
     ///     and file size.
     /// </summary>
-    /// <param name="archive">The archive that contains the entry.</param>
-    /// <param name="entryName">The name of the entry.</param>
-    /// <param name="fileSize">The size of the file.</param>
+    /// <param name="archive">
+    ///     The archive that contains the entry.
+    /// </param>
+    /// <param name="entryName">
+    ///     The name of the entry.
+    /// </param>
+    /// <param name="fileSize">
+    ///     The size of the file.
+    /// </param>
     public DataArchiveEntry(DataArchive archive, string entryName, int fileSize)
         : this(
             archive,
@@ -43,10 +49,11 @@ public sealed class DataArchiveEntry(
             fileSize) { }
 
     /// <summary>
-    ///     Returns a dedicated stream for the portion of data for this entry.
-    ///     Dedicated streams can be used concurrently.
+    ///     Returns a dedicated stream for the portion of data for this entry. Dedicated streams can be used concurrently.
     /// </summary>
-    /// <exception cref="ArgumentOutOfRangeException">If the archive's stream is of an unexpected type</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     If the archive's stream is of an unexpected type
+    /// </exception>
     public Stream ToDedicatedStream()
     {
         archive.ThrowIfDisposed();
@@ -97,10 +104,12 @@ public sealed class DataArchiveEntry(
     }
 
     /// <summary>
-    ///     Returns a segment of the underlying stream that represents the portion of data for this entry.
-    ///     Segments of an underlying stream should not be used concurrently.
+    ///     Returns a segment of the underlying stream that represents the portion of data for this entry. Segments of an
+    ///     underlying stream should not be used concurrently.
     /// </summary>
-    /// <param name="leaveOpen">Whether or not to leave the underlying stream open when this segment is disposed</param>
+    /// <param name="leaveOpen">
+    ///     Whether or not to leave the underlying stream open when this segment is disposed
+    /// </param>
     public Stream ToStreamSegment(bool leaveOpen = true)
     {
         archive.ThrowIfDisposed();
@@ -111,9 +120,15 @@ public sealed class DataArchiveEntry(
     /// <summary>
     ///     Attempts to retrieve a numeric identifier from the EntryName property.
     /// </summary>
-    /// <param name="identifier">The retrieved numeric identifier, if successful.</param>
-    /// <param name="numDigits">The maximum number of digits to consider as the identifier.</param>
-    /// <returns>True if a numeric identifier is successfully retrieved, false otherwise.</returns>
+    /// <param name="identifier">
+    ///     The retrieved numeric identifier, if successful.
+    /// </param>
+    /// <param name="numDigits">
+    ///     The maximum number of digits to consider as the identifier.
+    /// </param>
+    /// <returns>
+    ///     True if a numeric identifier is successfully retrieved, false otherwise.
+    /// </returns>
     public bool TryGetNumericIdentifier(out int identifier, int numDigits = int.MaxValue)
     {
         identifier = -1;

--- a/DALib/Data/DataArchiveEntry.cs
+++ b/DALib/Data/DataArchiveEntry.cs
@@ -49,72 +49,25 @@ public sealed class DataArchiveEntry(
             fileSize) { }
 
     /// <summary>
-    ///     Returns a dedicated stream for the portion of data for this entry. Dedicated streams can be used concurrently.
-    /// </summary>
-    /// <exception cref="ArgumentOutOfRangeException">
-    ///     If the archive's stream is of an unexpected type
-    /// </exception>
-    public Stream ToDedicatedStream()
-    {
-        archive.ThrowIfDisposed();
-
-        switch (archive.DataStream)
-        {
-            case FileStream fileStream:
-            {
-                var dedicatedFileStream = new FileStream(
-                    fileStream.Name,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.ReadWrite);
-
-                //if this segment is closed, close the underlying filestream (leaveOpen: false)
-                return dedicatedFileStream.Slice(Address, FileSize, false);
-            }
-            case MemoryStream:
-            {
-                //apparently there's no good way to copy memoryStreams to eachother with offset/length
-                //so the best way to do it is to copy the segment to a new MemoryStream
-                using var segment = ToStreamSegment();
-                var dedicatedMemoryStream = new MemoryStream(FileSize);
-
-                segment.CopyTo(dedicatedMemoryStream);
-
-                dedicatedMemoryStream.Seek(0, SeekOrigin.Begin);
-
-                return dedicatedMemoryStream;
-            }
-            default:
-                throw new ArgumentOutOfRangeException(nameof(archive.DataStream), "Encountered unexpected stream type");
-        }
-    }
-
-    /// <summary>
     ///     Converts the entry to a span of bytes
     /// </summary>
     public Span<byte> ToSpan()
     {
         archive.ThrowIfDisposed();
 
-        archive.DataStream!.Seek(Address, SeekOrigin.Begin);
-        var span = new Span<byte>(new byte[FileSize]);
-        _ = archive.DataStream.Read(span);
+        using var segment = ToStreamSegment();
 
-        return span;
+        return segment.ToSpan();
     }
 
     /// <summary>
-    ///     Returns a segment of the underlying stream that represents the portion of data for this entry. Segments of an
-    ///     underlying stream should not be used concurrently.
+    ///     Returns a segment of the underlying stream that represents the portion of data for this entry
     /// </summary>
-    /// <param name="leaveOpen">
-    ///     Whether or not to leave the underlying stream open when this segment is disposed
-    /// </param>
-    public Stream ToStreamSegment(bool leaveOpen = true)
+    public Stream ToStreamSegment()
     {
         archive.ThrowIfDisposed();
 
-        return archive.DataStream!.Slice(Address, FileSize, leaveOpen);
+        return archive.GetEntryStream(this);
     }
 
     /// <summary>

--- a/DALib/Data/MapFile.cs
+++ b/DALib/Data/MapFile.cs
@@ -51,10 +51,18 @@ public sealed class MapFile(int width, int height) : ISavable
     /// <summary>
     ///     Loads a MapFile from the specified path
     /// </summary>
-    /// <param name="path">The path to the file to read.</param>
-    /// <param name="width">The width of the map.</param>
-    /// <param name="height">The height of the map.</param>
-    /// <returns>A new instance of the MapFile class.</returns>
+    /// <param name="path">
+    ///     The path to the file to read.
+    /// </param>
+    /// <param name="width">
+    ///     The width of the map.
+    /// </param>
+    /// <param name="height">
+    ///     The height of the map.
+    /// </param>
+    /// <returns>
+    ///     A new instance of the MapFile class.
+    /// </returns>
     public static MapFile FromFile(string path, int width, int height)
     {
         using var stream = File.Open(
@@ -74,9 +82,15 @@ public sealed class MapFile(int width, int height) : ISavable
     /// <summary>
     ///     Gets the MapTile at the specified coordinates.
     /// </summary>
-    /// <param name="x">The x-coordinate of the MapTile.</param>
-    /// <param name="y">The y-coordinate of the MapTile.</param>
-    /// <returns>The MapTile at the specified coordinates.</returns>
+    /// <param name="x">
+    ///     The x-coordinate of the MapTile.
+    /// </param>
+    /// <param name="y">
+    ///     The y-coordinate of the MapTile.
+    /// </param>
+    /// <returns>
+    ///     The MapTile at the specified coordinates.
+    /// </returns>
     public MapTile this[int x, int y] => Tiles[x, y];
 
     #region SaveTo

--- a/DALib/Data/MemoryMappedDataArchive.cs
+++ b/DALib/Data/MemoryMappedDataArchive.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using DALib.Abstractions;
+
+namespace DALib.Data;
+
+/// <summary>
+///     A <see cref="DataArchive" /> that utilizes Memory Mapped Files, so that the entire archvive is not loaded into
+///     memory.
+/// </summary>
+public sealed class MemoryMappedDataArchive : DataArchive
+{
+    private readonly MemoryMappedFile MappedFile;
+
+    internal MemoryMappedDataArchive(MemoryMappedFile mappedFile, bool newFormat = false)
+        : base(mappedFile.CreateViewStream(0, 0, MemoryMappedFileAccess.Read), newFormat)
+        => MappedFile = mappedFile;
+
+    /// <inheritdoc />
+    public override void Dispose()
+    {
+        MappedFile.Dispose();
+        base.Dispose();
+    }
+
+    /// <inheritdoc />
+    public override Stream GetEntryStream(DataArchiveEntry entry)
+        => MappedFile.CreateViewStream(entry.Address, entry.FileSize, MemoryMappedFileAccess.Read);
+
+    /// <inheritdoc />
+    public override void Patch(string entryName, ISavable item) => throw new NotSupportedException("Cannot patch a memory-mapped archive.");
+
+    /// <inheritdoc />
+    public override void Save(string path) => throw new NotSupportedException("Cannot save a memory-mapped archive.");
+
+    /// <inheritdoc />
+    public override void Save(Stream stream) => throw new NotSupportedException("Cannot save a memory-mapped archive.");
+}

--- a/DALib/Data/MetaFile.cs
+++ b/DALib/Data/MetaFile.cs
@@ -48,8 +48,12 @@ public sealed class MetaFile : Collection<MetaFileEntry>, ISavable
     /// <summary>
     ///     Loads a MetaFile from the specified path
     /// </summary>
-    /// <param name="path">The path of the file.</param>
-    /// <param name="isCompressed">A value indicating whether the file is compressed.</param>
+    /// <param name="path">
+    ///     The path of the file.
+    /// </param>
+    /// <param name="isCompressed">
+    ///     A value indicating whether the file is compressed.
+    /// </param>
     public static MetaFile FromFile(string path, bool isCompressed)
     {
         using var stream = File.Open(

--- a/DALib/Definitions/Enums.cs
+++ b/DALib/Definitions/Enums.cs
@@ -6,18 +6,18 @@ namespace DALib.Definitions;
 public enum Endianness
 {
     /// <summary>
-    ///     Little endian is a term used to describe the byte order of multi-byte data types in computer memory.
-    ///     In little endian, the least significant byte (LSB) is stored at the lowest memory address,
-    ///     and the most significant byte (MSB) is stored at the highest memory address.
-    ///     In other words, the bytes are ordered from the smallest to the largest, based on their significance.
+    ///     Little endian is a term used to describe the byte order of multi-byte data types in computer memory. In little
+    ///     endian, the least significant byte (LSB) is stored at the lowest memory address, and the most significant byte
+    ///     (MSB) is stored at the highest memory address. In other words, the bytes are ordered from the smallest to the
+    ///     largest, based on their significance.
     /// </summary>
     LittleEndian,
 
     /// <summary>
-    ///     Big endian is a term used to describe the byte order of multi-byte data types in computer memory.
-    ///     In big endian, the most significant byte (MSB) is stored at the lowest memory address,
-    ///     and the least significant byte (LSB) is stored at the highest memory address.
-    ///     In other words, the bytes are ordered from the largest to the smallest, based on their significance.
+    ///     Big endian is a term used to describe the byte order of multi-byte data types in computer memory. In big endian,
+    ///     the most significant byte (MSB) is stored at the lowest memory address, and the least significant byte (LSB) is
+    ///     stored at the highest memory address. In other words, the bytes are ordered from the largest to the smallest, based
+    ///     on their significance.
     /// </summary>
     BigEndian
 }

--- a/DALib/Drawing/ColorTable.cs
+++ b/DALib/Drawing/ColorTable.cs
@@ -60,8 +60,12 @@ public sealed class ColorTable() : KeyedCollection<int, ColorTableEntry>
     /// <summary>
     ///     Loads a ColorTable from the specified archive entry
     /// </summary>
-    /// <param name="entry">The DataArchiveEntry to convert into a ColorTable.</param>
-    /// <returns>A ColorTable object created from the provided DataArchiveEntry.</returns>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to convert into a ColorTable.
+    /// </param>
+    /// <returns>
+    ///     A ColorTable object created from the provided DataArchiveEntry.
+    /// </returns>
     public static ColorTable FromEntry(DataArchiveEntry entry)
     {
         using var segment = entry.ToStreamSegment();
@@ -72,8 +76,12 @@ public sealed class ColorTable() : KeyedCollection<int, ColorTableEntry>
     /// <summary>
     ///     Loads a ColorTable from the specified path
     /// </summary>
-    /// <param name="path">The path to the color table file.</param>
-    /// <returns>The color table read from the file.</returns>
+    /// <param name="path">
+    ///     The path to the color table file.
+    /// </param>
+    /// <returns>
+    ///     The color table read from the file.
+    /// </returns>
     public static ColorTable FromFile(string path)
     {
         using var stream = File.Open(

--- a/DALib/Drawing/ControlFile.cs
+++ b/DALib/Drawing/ControlFile.cs
@@ -23,10 +23,12 @@ public sealed class ControlFile : KeyedCollection<string, Control>
     /// <summary>
     ///     Loads all ControlFiles from the given <see cref="DataArchive" />.
     /// </summary>
-    /// <param name="archive">The <see cref="DataArchive" /> containing the control files.</param>
+    /// <param name="archive">
+    ///     The <see cref="DataArchive" /> containing the control files.
+    /// </param>
     /// <returns>
-    ///     A dictionary of control files, where the key is the filename without extension and the value is the
-    ///     corresponding <see cref="ControlFile" /> instance.
+    ///     A dictionary of control files, where the key is the filename without extension and the value is the corresponding
+    ///     <see cref="ControlFile" /> instance.
     /// </returns>
     public static Dictionary<string, ControlFile> FromArchive(DataArchive archive)
     {
@@ -51,10 +53,12 @@ public sealed class ControlFile : KeyedCollection<string, Control>
     /// <summary>
     ///     Loads a ControlFile from the specified archive entry.
     /// </summary>
-    /// <param name="entry">The DataArchiveEntry to create the ControlFile from.</param>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to create the ControlFile from.
+    /// </param>
     /// <param name="parser">
-    ///     An optional ControlFileParser to use for parsing the ControlFile. If this is not specified, the
-    ///     default parser will be used
+    ///     An optional ControlFileParser to use for parsing the ControlFile. If this is not specified, the default parser will
+    ///     be used
     /// </param>
     public static ControlFile FromEntry(DataArchiveEntry entry, ControlFileParser? parser = null)
     {
@@ -66,12 +70,16 @@ public sealed class ControlFile : KeyedCollection<string, Control>
     /// <summary>
     ///     Loads a ControlFile from the specified path
     /// </summary>
-    /// <param name="path">The path of the control file to read.</param>
-    /// <param name="parser">
-    ///     An optional ControlFileParser to use for parsing the ControlFile. If this is not specified, the
-    ///     default parser will be used
+    /// <param name="path">
+    ///     The path of the control file to read.
     /// </param>
-    /// <returns>A ControlFile object representing the contents of the control file.</returns>
+    /// <param name="parser">
+    ///     An optional ControlFileParser to use for parsing the ControlFile. If this is not specified, the default parser will
+    ///     be used
+    /// </param>
+    /// <returns>
+    ///     A ControlFile object representing the contents of the control file.
+    /// </returns>
     public static ControlFile FromFile(string path, ControlFileParser? parser = null)
     {
         using var stream = File.Open(

--- a/DALib/Drawing/EfaFile.cs
+++ b/DALib/Drawing/EfaFile.cs
@@ -32,14 +32,12 @@ public sealed class EfaFile : Collection<EfaFrame>, ISavable
     public int FrameIntervalMs { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public int Unknown1 { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public byte[] Unknown2 { get; set; }
 
@@ -129,8 +127,12 @@ public sealed class EfaFile : Collection<EfaFrame>, ISavable
     /// <summary>
     ///     Loads an EfaFile with the specified fileName from the specified archive
     /// </summary>
-    /// <param name="fileName">The name of the EFA file to search for in the archive.</param>
-    /// <param name="archive">The DataArchive from which to retrieve the EFA file.</param>
+    /// <param name="fileName">
+    ///     The name of the EFA file to search for in the archive.
+    /// </param>
+    /// <param name="archive">
+    ///     The DataArchive from which to retrieve the EFA file.
+    /// </param>
     /// <exception cref="FileNotFoundException">
     ///     Thrown if the EFA file with the specified name is not found in the archive.
     /// </exception>
@@ -145,7 +147,9 @@ public sealed class EfaFile : Collection<EfaFrame>, ISavable
     /// <summary>
     ///     Loads an EfaFile from the specified archive entry
     /// </summary>
-    /// <param name="entry">The DataArchiveEntry to load the EfaFile from</param>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to load the EfaFile from
+    /// </param>
     public static EfaFile FromEntry(DataArchiveEntry entry)
     {
         using var segment = entry.ToStreamSegment();
@@ -156,7 +160,9 @@ public sealed class EfaFile : Collection<EfaFrame>, ISavable
     /// <summary>
     ///     Loads an EfaFile from the specified path
     /// </summary>
-    /// <param name="path">The path of the file to be read.</param>
+    /// <param name="path">
+    ///     The path of the file to be read.
+    /// </param>
     public static EfaFile FromFile(string path)
     {
         using var stream = File.Open(
@@ -175,13 +181,17 @@ public sealed class EfaFile : Collection<EfaFrame>, ISavable
     /// <summary>
     ///     Converts a sequence of fully colored images to an EfaFile.
     /// </summary>
-    /// <param name="orderedFrames">The ordered collection of SKImage frames.</param>
+    /// <param name="orderedFrames">
+    ///     The ordered collection of SKImage frames.
+    /// </param>
     public static EfaFile FromImages(IEnumerable<SKImage> orderedFrames) => FromImages(orderedFrames.ToArray());
 
     /// <summary>
     ///     Converts a collection of fully colored images to an EfaFile
     /// </summary>
-    /// <param name="orderedFrames">The ordered array of SKImage frames.</param>
+    /// <param name="orderedFrames">
+    ///     The ordered array of SKImage frames.
+    /// </param>
     public static EfaFile FromImages(params SKImage[] orderedFrames)
     {
         var efaFile = new EfaFile();

--- a/DALib/Drawing/EfaFrame.cs
+++ b/DALib/Drawing/EfaFrame.cs
@@ -86,44 +86,37 @@ public sealed class EfaFrame
     public short Top { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public int Unknown1 { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public int Unknown2 { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public int Unknown3 { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public int Unknown4 { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public int Unknown5 { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public int Unknown6 { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public int Unknown7 { get; set; }
 }

--- a/DALib/Drawing/EpfFile.cs
+++ b/DALib/Drawing/EpfFile.cs
@@ -28,16 +28,19 @@ public sealed class EpfFile : Collection<EpfFrame>, ISavable
     public short PixelWidth { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public byte[] UnknownBytes { get; set; }
 
     /// <summary>
     ///     Initializes a new instance of the EpfFile class with the specified width and height.
     /// </summary>
-    /// <param name="width">The width of the EpfFile.</param>
-    /// <param name="height">The height of the EpfFile.</param>
+    /// <param name="width">
+    ///     The width of the EpfFile.
+    /// </param>
+    /// <param name="height">
+    ///     The height of the EpfFile.
+    /// </param>
     public EpfFile(short width, short height)
     {
         PixelHeight = height;
@@ -163,8 +166,12 @@ public sealed class EpfFile : Collection<EpfFrame>, ISavable
     /// <summary>
     ///     Loads an EpfFile with the specified fileName from the specified archive
     /// </summary>
-    /// <param name="fileName">The name of the EPF file to extract from the archive.</param>
-    /// <param name="archive">The DataArchive from which to retrieve the EPF file.</param>
+    /// <param name="fileName">
+    ///     The name of the EPF file to extract from the archive.
+    /// </param>
+    /// <param name="archive">
+    ///     The DataArchive from which to retrieve the EPF file.
+    /// </param>
     /// <exception cref="FileNotFoundException">
     ///     Thrown if the EPF file with the specified name is not found in the archive.
     /// </exception>
@@ -179,7 +186,9 @@ public sealed class EpfFile : Collection<EpfFrame>, ISavable
     /// <summary>
     ///     Loads an EpfFile from the specified archive entry
     /// </summary>
-    /// <param name="entry">The DataArchiveEntry to load the EpfFile from</param>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to load the EpfFile from
+    /// </param>
     public static EpfFile FromEntry(DataArchiveEntry entry)
     {
         using var segment = entry.ToStreamSegment();
@@ -190,7 +199,9 @@ public sealed class EpfFile : Collection<EpfFrame>, ISavable
     /// <summary>
     ///     Loads an EpfFile from the specified path
     /// </summary>
-    /// <param name="path">The path of the file to be read.</param>
+    /// <param name="path">
+    ///     The path of the file to be read.
+    /// </param>
     public static EpfFile FromFile(string path)
     {
         using var stream = File.Open(
@@ -210,10 +221,12 @@ public sealed class EpfFile : Collection<EpfFrame>, ISavable
     ///     Converts a sequence of fully colored images to an EpfFile.
     /// </summary>
     /// <param name="options">
-    ///     Options to be used for quantization. EpfFiles can only have a maximum of 256 colors due to being
-    ///     a palettized format
+    ///     Options to be used for quantization. EpfFiles can only have a maximum of 256 colors due to being a palettized
+    ///     format
     /// </param>
-    /// <param name="orderedFrames">The ordered collection of SKImage frames.</param>
+    /// <param name="orderedFrames">
+    ///     The ordered collection of SKImage frames.
+    /// </param>
     public static Palettized<EpfFile> FromImages(QuantizerOptions options, IEnumerable<SKImage> orderedFrames)
         => FromImages(options, orderedFrames.ToArray());
 
@@ -221,10 +234,12 @@ public sealed class EpfFile : Collection<EpfFrame>, ISavable
     ///     Converts a collection of fully colored images to an EpfFile
     /// </summary>
     /// <param name="options">
-    ///     Options to be used for quantization. EpfFiles can only have a maximum of 256 colors due to being
-    ///     a palettized format
+    ///     Options to be used for quantization. EpfFiles can only have a maximum of 256 colors due to being a palettized
+    ///     format
     /// </param>
-    /// <param name="orderedFrames">The ordered array of SKImage frames.</param>
+    /// <param name="orderedFrames">
+    ///     The ordered array of SKImage frames.
+    /// </param>
     public static Palettized<EpfFile> FromImages(QuantizerOptions options, params SKImage[] orderedFrames)
     {
         ImageProcessor.PreserveNonTransparentBlacks(orderedFrames);

--- a/DALib/Drawing/Graphics.cs
+++ b/DALib/Drawing/Graphics.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using System.Text;
 using DALib.Data;
 using DALib.Definitions;
@@ -17,8 +18,12 @@ public static class Graphics
     /// <summary>
     ///     Renders an EpfFrame
     /// </summary>
-    /// <param name="frame">The frame to render</param>
-    /// <param name="palette">A palette containing colors used by the frame</param>
+    /// <param name="frame">
+    ///     The frame to render
+    /// </param>
+    /// <param name="palette">
+    ///     A palette containing colors used by the frame
+    /// </param>
     public static SKImage RenderImage(EpfFrame frame, Palette palette)
         => SimpleRender(
             frame.Left,
@@ -31,8 +36,12 @@ public static class Graphics
     /// <summary>
     ///     Renders an MpfFrame
     /// </summary>
-    /// <param name="frame">The frame to render</param>
-    /// <param name="palette">A palette containing colors used by the frame</param>
+    /// <param name="frame">
+    ///     The frame to render
+    /// </param>
+    /// <param name="palette">
+    ///     A palette containing colors used by the frame
+    /// </param>
     public static SKImage RenderImage(MpfFrame frame, Palette palette)
         => SimpleRender(
             frame.Left,
@@ -45,8 +54,12 @@ public static class Graphics
     /// <summary>
     ///     Renders an HpfFile
     /// </summary>
-    /// <param name="hpf">The file to render</param>
-    /// <param name="palette">A palette containing colors used by the frame</param>
+    /// <param name="hpf">
+    ///     The file to render
+    /// </param>
+    /// <param name="palette">
+    ///     A palette containing colors used by the frame
+    /// </param>
     public static SKImage RenderImage(HpfFile hpf, Palette palette)
         => SimpleRender(
             0,
@@ -59,8 +72,12 @@ public static class Graphics
     /// <summary>
     ///     Renders a palettized SPF frame
     /// </summary>
-    /// <param name="spf">The frame to render. Must be a palettized SpfFrame</param>
-    /// <param name="spfPrimaryColorPalette">The primary color palette of the SpfFile. (see SpfFile.Format)</param>
+    /// <param name="spf">
+    ///     The frame to render. Must be a palettized SpfFrame
+    /// </param>
+    /// <param name="spfPrimaryColorPalette">
+    ///     The primary color palette of the SpfFile. (see SpfFile.Format)
+    /// </param>
     public static SKImage RenderImage(SpfFrame spf, Palette spfPrimaryColorPalette)
         => SimpleRender(
             spf.Left,
@@ -73,7 +90,9 @@ public static class Graphics
     /// <summary>
     ///     Renders a colorized SpfFrame
     /// </summary>
-    /// <param name="spf">The frame to render. Must be a colorized SpfFrame. (see SpfFile.Format)</param>
+    /// <param name="spf">
+    ///     The frame to render. Must be a colorized SpfFrame. (see SpfFile.Format)
+    /// </param>
     public static SKImage RenderImage(SpfFrame spf)
         => SimpleRender(
             spf.Left,
@@ -85,8 +104,12 @@ public static class Graphics
     /// <summary>
     ///     Renders an EfaFrame
     /// </summary>
-    /// <param name="efa">The frame to render</param>
-    /// <param name="efaBlendingType">The alpha blending type to use</param>
+    /// <param name="efa">
+    ///     The frame to render
+    /// </param>
+    /// <param name="efaBlendingType">
+    ///     The alpha blending type to use
+    /// </param>
     public static SKImage RenderImage(EfaFrame efa, EfaBlendingType efaBlendingType = EfaBlendingType.Luminance)
     {
         using var bitmap = new SKBitmap(
@@ -96,6 +119,9 @@ public static class Graphics
             SKAlphaType.Premul);
 
         bitmap.Erase(CONSTANTS.Transparent);
+
+        var pixeMap = new SKPixmap(bitmap.Info, bitmap.GetPixels());
+        var pixelBuffer = pixeMap.GetPixelSpan<SKColor>();
 
         if (efa.ByteCount == 0)
             return SKImage.FromBitmap(bitmap);
@@ -138,7 +164,7 @@ public static class Graphics
                 if (coefficient > 0)
                     color = color.WithLuminanceAlpha(coefficient);
 
-                bitmap.SetPixel(xActual, yActual, color);
+                pixelBuffer[yActual * bitmap.Width + xActual] = color;
             }
 
         return SKImage.FromBitmap(bitmap);
@@ -147,9 +173,15 @@ public static class Graphics
     /// <summary>
     ///     Renders a MapFile, given the archives that contain required data
     /// </summary>
-    /// <param name="map">The map file to render.</param>
-    /// <param name="seoDat">The SEO archive.</param>
-    /// <param name="iaDat">The IA archive.</param>
+    /// <param name="map">
+    ///     The map file to render.
+    /// </param>
+    /// <param name="seoDat">
+    ///     The SEO archive.
+    /// </param>
+    /// <param name="iaDat">
+    ///     The IA archive.
+    /// </param>
     public static SKImage RenderMap(MapFile map, DataArchive seoDat, DataArchive iaDat)
         => RenderMap(
             map,
@@ -163,11 +195,21 @@ public static class Graphics
     /// <summary>
     ///     Renders a MapFile, given already extracted information
     /// </summary>
-    /// <param name="map">The MapFile to render</param>
-    /// <param name="tiles">A collection of background tiles</param>
-    /// <param name="bgPaletteLookup">PaletteLookup for background tiles</param>
-    /// <param name="fgPaletteLookup">PaletteLookup for foreground tiles</param>
-    /// <param name="iaDat">IA archive for reading foreground tile files</param>
+    /// <param name="map">
+    ///     The MapFile to render
+    /// </param>
+    /// <param name="tiles">
+    ///     A collection of background tiles
+    /// </param>
+    /// <param name="bgPaletteLookup">
+    ///     PaletteLookup for background tiles
+    /// </param>
+    /// <param name="fgPaletteLookup">
+    ///     PaletteLookup for foreground tiles
+    /// </param>
+    /// <param name="iaDat">
+    ///     IA archive for reading foreground tile files
+    /// </param>
     public static SKImage RenderMap(
         MapFile map,
         Tileset tiles,
@@ -285,8 +327,12 @@ public static class Graphics
     /// <summary>
     ///     Renders a Tile
     /// </summary>
-    /// <param name="tile">The tile to render</param>
-    /// <param name="palette">A palette containing colors used by the tile</param>
+    /// <param name="tile">
+    ///     The tile to render
+    /// </param>
+    /// <param name="palette">
+    ///     A palette containing colors used by the tile
+    /// </param>
     public static SKImage RenderTile(Tile tile, Palette palette)
         => SimpleRender(
             0,
@@ -305,7 +351,8 @@ public static class Graphics
     {
         using var bitmap = new SKBitmap(width + left, height + top);
 
-        bitmap.Erase(CONSTANTS.Transparent);
+        var pixelBuffer = new SKColor[bitmap.Width * bitmap.Height];
+        Array.Fill(pixelBuffer, CONSTANTS.Transparent);
 
         for (var y = 0; y < height; y++)
             for (var x = 0; x < width; x++)
@@ -319,8 +366,17 @@ public static class Graphics
                 if ((color == CONSTANTS.Transparent) || (color == SKColors.Black))
                     continue;
 
-                bitmap.SetPixel(xActual, yActual, color);
+                pixelBuffer[yActual * bitmap.Width + xActual] = color;
             }
+
+        var handle = GCHandle.Alloc(pixelBuffer, GCHandleType.Pinned);
+
+        bitmap.InstallPixels(
+            bitmap.Info,
+            handle.AddrOfPinnedObject(),
+            bitmap.RowBytes,
+            Helpers.FreeHandle,
+            handle);
 
         return SKImage.FromBitmap(bitmap);
     }
@@ -335,7 +391,8 @@ public static class Graphics
     {
         using var bitmap = new SKBitmap(width + left, height + top);
 
-        bitmap.Erase(CONSTANTS.Transparent);
+        var pixelBuffer = new SKColor[bitmap.Width * bitmap.Height];
+        Array.Fill(pixelBuffer, CONSTANTS.Transparent);
 
         for (var y = 0; y < height; y++)
             for (var x = 0; x < width; x++)
@@ -349,8 +406,17 @@ public static class Graphics
                 //if the paletteIndex is 0, and that color is pure black or transparent black
                 var color = paletteIndex == 0 ? CONSTANTS.Transparent : palette[paletteIndex];
 
-                bitmap.SetPixel(xActual, yActual, color);
+                pixelBuffer[yActual * bitmap.Width + xActual] = color;
             }
+
+        var handle = GCHandle.Alloc(pixelBuffer, GCHandleType.Pinned);
+
+        bitmap.InstallPixels(
+            bitmap.Info,
+            handle.AddrOfPinnedObject(),
+            bitmap.RowBytes,
+            Helpers.FreeHandle,
+            handle);
 
         return SKImage.FromBitmap(bitmap);
     }

--- a/DALib/Drawing/HpfFile.cs
+++ b/DALib/Drawing/HpfFile.cs
@@ -42,8 +42,12 @@ public sealed class HpfFile : ISavable
     /// <summary>
     ///     Initializes a new instance of the HpfFile class using the specified header bytes and data bytes
     /// </summary>
-    /// <param name="headerBytes">The header bytes of the HPF file.</param>
-    /// <param name="data">The data bytes of the HPF file.</param>
+    /// <param name="headerBytes">
+    ///     The header bytes of the HPF file.
+    /// </param>
+    /// <param name="data">
+    ///     The data bytes of the HPF file.
+    /// </param>
     public HpfFile(byte[] headerBytes, byte[] data)
     {
         HeaderBytes = headerBytes;
@@ -100,10 +104,12 @@ public sealed class HpfFile : ISavable
     ///     Converts a fully colorized image to an HpfFile
     /// </summary>
     /// <param name="options">
-    ///     Options to be used for quantization. EpfFiles can only have a maximum of 256 colors due to being
-    ///     a palettized format
+    ///     Options to be used for quantization. EpfFiles can only have a maximum of 256 colors due to being a palettized
+    ///     format
     /// </param>
-    /// <param name="image">A fully colorized SKImage</param>
+    /// <param name="image">
+    ///     A fully colorized SKImage
+    /// </param>
     public static Palettized<HpfFile> FromImage(QuantizerOptions options, SKImage image)
     {
         using var quantized = ImageProcessor.Quantize(options, image);
@@ -120,8 +126,12 @@ public sealed class HpfFile : ISavable
     /// <summary>
     ///     Loads an HpfFile with the specified fileName from the specified archive
     /// </summary>
-    /// <param name="fileName">The name of the HPF file to extract from the archive</param>
-    /// <param name="archive">The DataArchive from which to retreive the HPF file</param>
+    /// <param name="fileName">
+    ///     The name of the HPF file to extract from the archive
+    /// </param>
+    /// <param name="archive">
+    ///     The DataArchive from which to retreive the HPF file
+    /// </param>
     /// <exception cref="FileNotFoundException">
     ///     Thrown if the HPF file with the specified name is not found in the archive.
     /// </exception>
@@ -136,13 +146,17 @@ public sealed class HpfFile : ISavable
     /// <summary>
     ///     Loads an HpfFile from the specified archive entry
     /// </summary>
-    /// <param name="entry">The DataArchiveEntry to load the HpfFile from</param>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to load the HpfFile from
+    /// </param>
     public static HpfFile FromEntry(DataArchiveEntry entry) => new(entry.ToSpan());
 
     /// <summary>
     ///     Loads an HpfFile from the specified path
     /// </summary>
-    /// <param name="path">The path of the file to be read.</param>
+    /// <param name="path">
+    ///     The path of the file to be read.
+    /// </param>
     public static HpfFile FromFile(string path)
     {
         using var stream = File.Open(

--- a/DALib/Drawing/MpfFile.cs
+++ b/DALib/Drawing/MpfFile.cs
@@ -93,11 +93,10 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
     public byte StopMotionFailureRatio { get; set; }
 
     /// <summary>
-    ///     Number of frames in the stationary action (For example, a guy continuously spinning nunchucks
-    ///     would need two frames for the spinning action, so it should be written as 2)
-    ///     Usually, it should be written as 0. If it's written as 0, it continuously repeats the entire action frame
-    ///     and if it's a number other than 0, it repeats only that many frames and occasionally animates with the remaining
-    ///     frames.
+    ///     Number of frames in the stationary action (For example, a guy continuously spinning nunchucks would need two frames
+    ///     for the spinning action, so it should be written as 2) Usually, it should be written as 0. If it's written as 0, it
+    ///     continuously repeats the entire action frame and if it's a number other than 0, it repeats only that many frames
+    ///     and occasionally animates with the remaining frames.
     /// </summary>
     public byte StopMotionFrameCount { get; set; }
 
@@ -119,10 +118,18 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
     /// <summary>
     ///     Initializes a new instance of the MpfFile class with the specified width and height.
     /// </summary>
-    /// <param name="headerType">Used to determine if 4 empty bytes will be written to the header</param>
-    /// <param name="formatType">Used to determine how many attack animations there are</param>
-    /// <param name="width">The pixel width of the image</param>
-    /// <param name="height">The pixel height of the image</param>
+    /// <param name="headerType">
+    ///     Used to determine if 4 empty bytes will be written to the header
+    /// </param>
+    /// <param name="formatType">
+    ///     Used to determine how many attack animations there are
+    /// </param>
+    /// <param name="width">
+    ///     The pixel width of the image
+    /// </param>
+    /// <param name="height">
+    ///     The pixel height of the image
+    /// </param>
     public MpfFile(
         MpfHeaderType headerType,
         MpfFormatType formatType,
@@ -352,11 +359,15 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
     ///     Converts a sequence of fully colorized images to an MpfFile
     /// </summary>
     /// <param name="options">
-    ///     Options to be used for quantization. EpfFiles can only have a maximum of 256 colors due to being
-    ///     a palettized format
+    ///     Options to be used for quantization. EpfFiles can only have a maximum of 256 colors due to being a palettized
+    ///     format
     /// </param>
-    /// <param name="formatType">The MpfFormat type of the resulting image</param>
-    /// <param name="orderedFrames">The ordered collection of SKImage frames.</param>
+    /// <param name="formatType">
+    ///     The MpfFormat type of the resulting image
+    /// </param>
+    /// <param name="orderedFrames">
+    ///     The ordered collection of SKImage frames.
+    /// </param>
     /// <remarks>
     ///     The resulting MpfFile will have a palette number of 0, and the indexes/frame counts/stopMotionRatio will not be
     ///     set. These details will need to manually be set by you.
@@ -368,11 +379,15 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
     ///     Converts a collection of fully colorized images to an MpfFile
     /// </summary>
     /// <param name="options">
-    ///     Options to be used for quantization. EpfFiles can only have a maximum of 256 colors due to being
-    ///     a palettized format
+    ///     Options to be used for quantization. EpfFiles can only have a maximum of 256 colors due to being a palettized
+    ///     format
     /// </param>
-    /// <param name="formatType">The MpfFormat type of the resulting image</param>
-    /// <param name="orderedFrames">The ordered collection of SKImage frames.</param>
+    /// <param name="formatType">
+    ///     The MpfFormat type of the resulting image
+    /// </param>
+    /// <param name="orderedFrames">
+    ///     The ordered collection of SKImage frames.
+    /// </param>
     /// <remarks>
     ///     The resulting MpfFile will have a palette number of 0, and the indexes/frame counts/stopMotionRatio will not be
     ///     set. These details will need to manually be set by you.
@@ -414,8 +429,12 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
     /// <summary>
     ///     Loads an MpfFile with the specified fileName from the specified archive
     /// </summary>
-    /// <param name="fileName">The name of the MPF file to extract from the archive.</param>
-    /// <param name="archive">The DataArchive from which to retreive the MPF file.</param>
+    /// <param name="fileName">
+    ///     The name of the MPF file to extract from the archive.
+    /// </param>
+    /// <param name="archive">
+    ///     The DataArchive from which to retreive the MPF file.
+    /// </param>
     /// <exception cref="FileNotFoundException">
     ///     Thrown if the MPF file with the specified name is not found in the archive.
     /// </exception>
@@ -430,8 +449,11 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
     /// <summary>
     ///     Loads an MpfFile from the specified archive entry
     /// </summary>
-    /// <param name="entry">The DataArchiveEntry to load the MpfFile from</param>
-    /// <returns></returns>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to load the MpfFile from
+    /// </param>
+    /// <returns>
+    /// </returns>
     public static MpfFile FromEntry(DataArchiveEntry entry)
     {
         using var segment = entry.ToStreamSegment();
@@ -442,7 +464,9 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
     /// <summary>
     ///     Loads an MpfFile from the specified path
     /// </summary>
-    /// <param name="path">The path of the file to be read.</param>
+    /// <param name="path">
+    ///     The path of the file to be read.
+    /// </param>
     public static MpfFile FromFile(string path)
     {
         using var stream = File.Open(

--- a/DALib/Drawing/Palette.cs
+++ b/DALib/Drawing/Palette.cs
@@ -35,7 +35,9 @@ public sealed class Palette : Collection<SKColor>, ISavable
     /// <summary>
     ///     Initializes a new instance of the Palette class with the specified colors
     /// </summary>
-    /// <param name="colors">The colors of the palette</param>
+    /// <param name="colors">
+    ///     The colors of the palette
+    /// </param>
     public Palette(IEnumerable<SKColor> colors)
         : this()
     {
@@ -49,8 +51,12 @@ public sealed class Palette : Collection<SKColor>, ISavable
     ///     Applies a dye to this palette beginning at the specified color index, and continuing for the length of the color
     ///     table entry
     /// </summary>
-    /// <param name="colorTableEntry">The color table entry to apply to this palette</param>
-    /// <param name="dyeIndexStart">The index to start copying colors to from the color table entry</param>
+    /// <param name="colorTableEntry">
+    ///     The color table entry to apply to this palette
+    /// </param>
+    /// <param name="dyeIndexStart">
+    ///     The index to start copying colors to from the color table entry
+    /// </param>
     /// <remarks>
     ///     This will create a new instance of the palette and return it. The existing palette instance will not be modified.
     ///     For the most part, this method is used to apply dye table entries to a palette, in which case the index start will
@@ -111,8 +117,12 @@ public sealed class Palette : Collection<SKColor>, ISavable
     /// <summary>
     ///     Loads all palettes from the specified archive that match the specified pattern
     /// </summary>
-    /// <param name="pattern">The pattern to match</param>
-    /// <param name="archive">The archive from which to extract palettes</param>
+    /// <param name="pattern">
+    ///     The pattern to match
+    /// </param>
+    /// <param name="archive">
+    ///     The archive from which to extract palettes
+    /// </param>
     public static Dictionary<int, Palette> FromArchive(string pattern, DataArchive archive)
     {
         var palettes = new Dictionary<int, Palette>();
@@ -131,7 +141,9 @@ public sealed class Palette : Collection<SKColor>, ISavable
     /// <summary>
     ///     Loads a palette from the specified archive entry
     /// </summary>
-    /// <param name="entry">The DataArchiveEntry to load the palette from</param>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to load the palette from
+    /// </param>
     public static Palette FromEntry(DataArchiveEntry entry)
     {
         using var segment = entry.ToStreamSegment();
@@ -142,7 +154,9 @@ public sealed class Palette : Collection<SKColor>, ISavable
     /// <summary>
     ///     Loads a palette from the specified path
     /// </summary>
-    /// <param name="path">The path of the file to be read.</param>
+    /// <param name="path">
+    ///     The path of the file to be read.
+    /// </param>
     public static Palette FromFile(string path)
     {
         using var stream = File.Open(

--- a/DALib/Drawing/PaletteLookup.cs
+++ b/DALib/Drawing/PaletteLookup.cs
@@ -41,10 +41,12 @@ public class PaletteLookup
     /// <summary>
     ///     Gets the palette for the specified id
     /// </summary>
-    /// <param name="id">The external id to look up the palette for</param>
+    /// <param name="id">
+    ///     The external id to look up the palette for
+    /// </param>
     /// <param name="khanPalOverrideType">
-    ///     An optional override used when working with KHAN archives that indicates if the
-    ///     lookup should favor male or female overrides
+    ///     An optional override used when working with KHAN archives that indicates if the lookup should favor male or female
+    ///     overrides
     /// </param>
     public Palette GetPaletteForId(int id, KhanPalOverrideType khanPalOverrideType = KhanPalOverrideType.None)
     {
@@ -93,8 +95,12 @@ public class PaletteLookup
     ///     Loads a PaletteLookup from the specified archive by searching for Palettes and PaletteTables that match the given
     ///     pattern
     /// </summary>
-    /// <param name="pattern">The pattern used to find Palettes and PaletteTables for this lookup</param>
-    /// <param name="archive">The archive to extract Palettes and PaletteTables from</param>
+    /// <param name="pattern">
+    ///     The pattern used to find Palettes and PaletteTables for this lookup
+    /// </param>
+    /// <param name="archive">
+    ///     The archive to extract Palettes and PaletteTables from
+    /// </param>
     public static PaletteLookup FromArchive(string pattern, DataArchive archive)
         => new(Palette.FromArchive(pattern, archive), PaletteTable.FromArchive(pattern, archive));
 
@@ -102,9 +108,15 @@ public class PaletteLookup
     ///     Loads a PaletteLookup from the specified archive by searching for Palettes and PaletteTables that match the given
     ///     tablePattern and palettePattern
     /// </summary>
-    /// <param name="tablePattern">The pattern used to find paletteTables for this lookup</param>
-    /// <param name="palettePattern">The pattern used to find palettes for this lookup</param>
-    /// <param name="archive">The archive to extract Palettes and PaletteTables from</param>
+    /// <param name="tablePattern">
+    ///     The pattern used to find paletteTables for this lookup
+    /// </param>
+    /// <param name="palettePattern">
+    ///     The pattern used to find palettes for this lookup
+    /// </param>
+    /// <param name="archive">
+    ///     The archive to extract Palettes and PaletteTables from
+    /// </param>
     public static PaletteLookup FromArchive(string tablePattern, string palettePattern, DataArchive archive)
         => new(Palette.FromArchive(palettePattern, archive), PaletteTable.FromArchive(tablePattern, archive));
     #endregion

--- a/DALib/Drawing/PaletteTable.cs
+++ b/DALib/Drawing/PaletteTable.cs
@@ -15,10 +15,10 @@ namespace DALib.Drawing;
 ///     Represents a palette table used to map external ids to palette ids
 /// </summary>
 /// <remarks>
-///     As a palette table is populated, newer entries override older ones. This is intended behavior.
-///     In my opinion this makes it meaningless to store and search through all of the entries.
-///     You could search through them in reverse order and return the first one you find, but even still...
-///     It should be faster this way, as a dictionary, where each id is mapped to a palette number
+///     As a palette table is populated, newer entries override older ones. This is intended behavior. In my opinion this
+///     makes it meaningless to store and search through all of the entries. You could search through them in reverse order
+///     and return the first one you find, but even still... It should be faster this way, as a dictionary, where each id
+///     is mapped to a palette number
 /// </remarks>
 public class PaletteTable : ISavable
 {
@@ -105,10 +105,17 @@ public class PaletteTable : ISavable
     /// <summary>
     ///     Adds a new entry to the palette table
     /// </summary>
-    /// <param name="id">The external id for which the specified palette number is mapped to</param>
-    /// <param name="paletteNumber">The id of the palette</param>
-    /// <param name="overrideType">The type of override to favor if this palette association is for a KHAN archive</param>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <param name="id">
+    ///     The external id for which the specified palette number is mapped to
+    /// </param>
+    /// <param name="paletteNumber">
+    ///     The id of the palette
+    /// </param>
+    /// <param name="overrideType">
+    ///     The type of override to favor if this palette association is for a KHAN archive
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// </exception>
     public virtual void Add(int id, int paletteNumber, KhanPalOverrideType overrideType = KhanPalOverrideType.None)
     {
         switch (overrideType)
@@ -138,8 +145,12 @@ public class PaletteTable : ISavable
     /// <summary>
     ///     Gets the palette number for the specified id
     /// </summary>
-    /// <param name="id">The external id for which to find the associated palette</param>
-    /// <param name="overrideType">The type of override to favor if working with a KHAN archive</param>
+    /// <param name="id">
+    ///     The external id for which to find the associated palette
+    /// </param>
+    /// <param name="overrideType">
+    ///     The type of override to favor if working with a KHAN archive
+    /// </param>
     public int GetPaletteNumber(int id, KhanPalOverrideType overrideType = KhanPalOverrideType.None)
     {
         // ReSharper disable once ConvertIfStatementToSwitchStatement
@@ -161,7 +172,9 @@ public class PaletteTable : ISavable
     /// <summary>
     ///     Merges the specified palette table into this one
     /// </summary>
-    /// <param name="other">Another palette table</param>
+    /// <param name="other">
+    ///     Another palette table
+    /// </param>
     public virtual void Merge(PaletteTable other)
     {
         foreach (var kvp in other.MaleOverrides)
@@ -180,7 +193,9 @@ public class PaletteTable : ISavable
     /// <summary>
     ///     Removes the specified id from the palette table (removes it from all collections)
     /// </summary>
-    /// <param name="id">The external id to remove</param>
+    /// <param name="id">
+    ///     The external id to remove
+    /// </param>
     public virtual void Remove(int id)
     {
         MaleOverrides.Remove(id);
@@ -285,9 +300,14 @@ public class PaletteTable : ISavable
     /// <summary>
     ///     Loads a palette table from the specified archive by searching for PaletteTables that match the given pattern
     /// </summary>
-    /// <param name="pattern">The pattern to match</param>
-    /// <param name="archive">The archive from which to extract PaletteTables</param>
-    /// <returns></returns>
+    /// <param name="pattern">
+    ///     The pattern to match
+    /// </param>
+    /// <param name="archive">
+    ///     The archive from which to extract PaletteTables
+    /// </param>
+    /// <returns>
+    /// </returns>
     public static PaletteTable FromArchive(string pattern, DataArchive archive)
     {
         var table = new PaletteTable();
@@ -305,7 +325,9 @@ public class PaletteTable : ISavable
     /// <summary>
     ///     Loads a palette table from the specified archive entry
     /// </summary>
-    /// <param name="entry">The DataArchiveEntry to load the palette table from</param>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to load the palette table from
+    /// </param>
     public static PaletteTable FromEntry(DataArchiveEntry entry)
     {
         using var segment = entry.ToStreamSegment();
@@ -316,7 +338,9 @@ public class PaletteTable : ISavable
     /// <summary>
     ///     Loads a palette table from the specified path
     /// </summary>
-    /// <param name="path">The path of the file to be read.</param>
+    /// <param name="path">
+    ///     The path of the file to be read.
+    /// </param>
     public static PaletteTable FromFile(string path)
     {
         using var stream = File.Open(

--- a/DALib/Drawing/SpfFile.cs
+++ b/DALib/Drawing/SpfFile.cs
@@ -38,22 +38,24 @@ public sealed class SpfFile : Collection<SpfFrame>, ISavable
     public Palette? SecondaryColors { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public uint Unknown1 { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public uint Unknown2 { get; set; }
 
     /// <summary>
     ///     Initializes a new instance of the SpfFile class(palettized) with the specified primary and secondary palettes
     /// </summary>
-    /// <param name="primaryColors">The primary color palette used by the images (RGB565 scaled to RGB888)</param>
-    /// <param name="secondaryColors">The secondary color palette used by the images (RGB555 scale to RGB888)</param>
+    /// <param name="primaryColors">
+    ///     The primary color palette used by the images (RGB565 scaled to RGB888)
+    /// </param>
+    /// <param name="secondaryColors">
+    ///     The secondary color palette used by the images (RGB555 scale to RGB888)
+    /// </param>
     public SpfFile(Palette primaryColors, Palette secondaryColors)
     {
         Format = SpfFormatType.Palettized;
@@ -336,13 +338,17 @@ public sealed class SpfFile : Collection<SpfFrame>, ISavable
     /// <summary>
     ///     Converts a sequence of fully colored images to a colorized SpfFile.
     /// </summary>
-    /// <param name="orderedFrames">The ordered collection of SKImage frames.</param>
+    /// <param name="orderedFrames">
+    ///     The ordered collection of SKImage frames.
+    /// </param>
     public static SpfFile FromImages(IEnumerable<SKImage> orderedFrames) => FromImages(orderedFrames.ToArray());
 
     /// <summary>
     ///     Converts a collection of fully colored images to a colorized SpfFile
     /// </summary>
-    /// <param name="orderedFrames">The ordered array of SKImage frames.</param>
+    /// <param name="orderedFrames">
+    ///     The ordered array of SKImage frames.
+    /// </param>
     public static SpfFile FromImages(params SKImage[] orderedFrames)
     {
         var spfFile = new SpfFile();
@@ -384,10 +390,12 @@ public sealed class SpfFile : Collection<SpfFrame>, ISavable
     ///     Converts a sequence of fully colored images to a palettized SpfFile.
     /// </summary>
     /// <param name="options">
-    ///     Options to be used for quantization. Palettized SpfFiles can only have a maximum of 256 colors due to being
-    ///     a palettized format
+    ///     Options to be used for quantization. Palettized SpfFiles can only have a maximum of 256 colors due to being a
+    ///     palettized format
     /// </param>
-    /// <param name="orderedFrames">The ordered collection of SKImage frames.</param>
+    /// <param name="orderedFrames">
+    ///     The ordered collection of SKImage frames.
+    /// </param>
     public static SpfFile FromImages(QuantizerOptions options, IEnumerable<SKImage> orderedFrames)
         => FromImages(options, orderedFrames.ToArray());
 
@@ -395,10 +403,12 @@ public sealed class SpfFile : Collection<SpfFrame>, ISavable
     ///     Converts a collection of fully colored images to a palettized SpfFile
     /// </summary>
     /// <param name="options">
-    ///     Options to be used for quantization. Palettized SpfFiles can only have a maximum of 256 colors due to being
-    ///     a palettized format
+    ///     Options to be used for quantization. Palettized SpfFiles can only have a maximum of 256 colors due to being a
+    ///     palettized format
     /// </param>
-    /// <param name="orderedFrames">The ordered array of SKImage frames.</param>
+    /// <param name="orderedFrames">
+    ///     The ordered array of SKImage frames.
+    /// </param>
     public static SpfFile FromImages(QuantizerOptions options, params SKImage[] orderedFrames)
     {
         ImageProcessor.PreserveNonTransparentBlacks(orderedFrames);
@@ -434,8 +444,12 @@ public sealed class SpfFile : Collection<SpfFrame>, ISavable
     /// <summary>
     ///     Loads an SpfFile with the specified fileName from the specified archive
     /// </summary>
-    /// <param name="fileName">The name of the SPF file to extract from the archive.</param>
-    /// <param name="archive">The DataArchive from which to retrieve the SPF file.</param>
+    /// <param name="fileName">
+    ///     The name of the SPF file to extract from the archive.
+    /// </param>
+    /// <param name="archive">
+    ///     The DataArchive from which to retrieve the SPF file.
+    /// </param>
     /// <exception cref="FileNotFoundException">
     ///     Thrown if the SPF file with the specified name is not found in the archive.
     /// </exception>
@@ -450,7 +464,9 @@ public sealed class SpfFile : Collection<SpfFrame>, ISavable
     /// <summary>
     ///     Loads an SpfFile from the specified archive entry
     /// </summary>
-    /// <param name="entry">The DataArchiveEntry to load the SpfFile from</param>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to load the SpfFile from
+    /// </param>
     public static SpfFile FromEntry(DataArchiveEntry entry)
     {
         using var segment = entry.ToStreamSegment();
@@ -461,7 +477,9 @@ public sealed class SpfFile : Collection<SpfFrame>, ISavable
     /// <summary>
     ///     Loads an SpfFile from the specified path
     /// </summary>
-    /// <param name="path">The path of the file to be read.</param>
+    /// <param name="path">
+    ///     The path of the file to be read.
+    /// </param>
     public static SpfFile FromFile(string path)
     {
         using var stream = File.Open(

--- a/DALib/Drawing/SpfFrame.cs
+++ b/DALib/Drawing/SpfFrame.cs
@@ -16,7 +16,8 @@ public sealed class SpfFrame
     ///     The number of bytes of image data this frame contains
     /// </summary>
     /// <remarks>
-    ///     For Palettized images, this will be equal to Height * Width <br />
+    ///     For Palettized images, this will be equal to Height * Width
+    ///     <br />
     ///     For Colorized images, this will be equal to Height * Width * 4 (2 bytes per pixel, 2 copies of the image data)
     /// </remarks>
     public uint ByteCount { get; set; }
@@ -25,7 +26,8 @@ public sealed class SpfFrame
     ///     The width of the image in bytes.
     /// </summary>
     /// <remarks>
-    ///     For Palettized images, this will be equal to Width <br />
+    ///     For Palettized images, this will be equal to Width
+    ///     <br />
     ///     For Colorized images, this will be equal to Width * 2 (2 bytes per pixel)
     /// </remarks>
     public uint ByteWidth { get; set; }
@@ -44,7 +46,8 @@ public sealed class SpfFrame
     ///     The number of byte per image
     /// </summary>
     /// <remarks>
-    ///     For Palettized images, this will be equal to Height * Width <br />
+    ///     For Palettized images, this will be equal to Height * Width
+    ///     <br />
     ///     For Colorized images, this will be equal to Height * Width * 2 (2 bytes per pixel)
     /// </remarks>
     public uint ImageByteCount { get; set; }
@@ -70,8 +73,7 @@ public sealed class SpfFrame
     public ushort Top { get; set; }
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public uint Unknown2 { get; set; }
 
@@ -86,8 +88,7 @@ public sealed class SpfFrame
     public int PixelWidth => Right - Left;
 
     /// <summary>
-    ///     A value that has an unknown use
-    ///     LI: figure out what this is for
+    ///     A value that has an unknown use LI: figure out what this is for
     /// </summary>
     public static uint Unknown1 => 0xCCCCCCCC; // Every SPF has this value associated with it
 }

--- a/DALib/Drawing/TileAnimationEntry.cs
+++ b/DALib/Drawing/TileAnimationEntry.cs
@@ -12,12 +12,9 @@ public sealed class TileAnimationEntry : IEnumerable<ushort>
     ///     The number of milliseconds to wait between each frame of the animation.
     /// </summary>
     /// <remarks>
-    ///     This property determines the delay between each frame in the animation.
-    ///     It is measured in milliseconds.
-    ///     The default value is 500 milliseconds.
-    ///     The actual duration of the interval is calculated by multiplying this
-    ///     value by 100. This is necessary because the value is stored in a
-    ///     text file as a hundredth of the desired interval time.
+    ///     This property determines the delay between each frame in the animation. It is measured in milliseconds. The default
+    ///     value is 500 milliseconds. The actual duration of the interval is calculated by multiplying this value by 100. This
+    ///     is necessary because the value is stored in a text file as a hundredth of the desired interval time.
     /// </remarks>
     public int AnimationIntervalMs { get; set; } = 500;
 
@@ -34,7 +31,9 @@ public sealed class TileAnimationEntry : IEnumerable<ushort>
     /// <summary>
     ///     Retrieves the ID of the next tile in the sequence, based on the given current tile ID.
     /// </summary>
-    /// <param name="currentTileId">The ID of the current tile</param>
+    /// <param name="currentTileId">
+    ///     The ID of the current tile
+    /// </param>
     public int GetNextTileId(ushort currentTileId)
     {
         var currentIndex = TileSequence.IndexOf(currentTileId);

--- a/DALib/Drawing/TileAnimationTable.cs
+++ b/DALib/Drawing/TileAnimationTable.cs
@@ -59,7 +59,9 @@ public class TileAnimationTable : ISavable
     /// <summary>
     ///     Adds a TileAnimationEntry to the table
     /// </summary>
-    /// <param name="entry">The TileAnimationEntry to be added.</param>
+    /// <param name="entry">
+    ///     The TileAnimationEntry to be added.
+    /// </param>
     public void Add(TileAnimationEntry entry)
     {
         foreach (var tileId in entry.TileSequence)
@@ -69,7 +71,9 @@ public class TileAnimationTable : ISavable
     /// <summary>
     ///     Removes a TileAnimationEntry from the table
     /// </summary>
-    /// <param name="entry">The TileAnimationEntry to remove.</param>
+    /// <param name="entry">
+    ///     The TileAnimationEntry to remove.
+    /// </param>
     public void Remove(TileAnimationEntry entry)
     {
         foreach (var tileId in entry.TileSequence)
@@ -113,8 +117,12 @@ public class TileAnimationTable : ISavable
     /// <summary>
     ///     Loads a TileAnimationTable with the specified fileName from the specified archive
     /// </summary>
-    /// <param name="fileName">The name of the TBL file to search for in the archive</param>
-    /// <param name="archive">The DataArchive from which to retrieve the TBL file.</param>
+    /// <param name="fileName">
+    ///     The name of the TBL file to search for in the archive
+    /// </param>
+    /// <param name="archive">
+    ///     The DataArchive from which to retrieve the TBL file.
+    /// </param>
     public static TileAnimationTable FromArchive(string fileName, DataArchive archive)
     {
         if (!archive.TryGetValue(fileName.WithExtension(".tbl"), out var entry))
@@ -126,7 +134,9 @@ public class TileAnimationTable : ISavable
     /// <summary>
     ///     Loads a TileAnimationTable from the specified entry
     /// </summary>
-    /// <param name="entry">The DataArchiveEntry to load the TileAnimationTable from.</param>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to load the TileAnimationTable from.
+    /// </param>
     public static TileAnimationTable FromEntry(DataArchiveEntry entry)
     {
         using var segment = entry.ToStreamSegment();
@@ -137,7 +147,9 @@ public class TileAnimationTable : ISavable
     /// <summary>
     ///     Loads a TileAnimationTable from the specified path
     /// </summary>
-    /// <param name="path">The path to the file to be read</param>
+    /// <param name="path">
+    ///     The path to the file to be read
+    /// </param>
     public static TileAnimationTable FromFile(string path)
     {
         using var stream = File.Open(

--- a/DALib/Drawing/Tileset.cs
+++ b/DALib/Drawing/Tileset.cs
@@ -80,7 +80,9 @@ public sealed class Tileset : Collection<Tile>, ISavable
     /// <summary>
     ///     Converts a sequence of fully colored images to a Tileset
     /// </summary>
-    /// <param name="images">The sequence of SKImages.</param>
+    /// <param name="images">
+    ///     The sequence of SKImages.
+    /// </param>
     /// <remarks>
     ///     This method will take a set of images and convert them to a Tileset. However, in order to save this tileset, you
     ///     will need to load the existing tilesets (tilea and tileas) from the archive and append this tileset to the existing
@@ -135,7 +137,9 @@ public sealed class Tileset : Collection<Tile>, ISavable
     /// <summary>
     ///     Converts a collection of fully colored images to a Tileset
     /// </summary>
-    /// <param name="images">The collection of SKImages.</param>
+    /// <param name="images">
+    ///     The collection of SKImages.
+    /// </param>
     /// <remarks>
     ///     This method will take a set of images and convert them to a Tileset. However, in order to save this tileset, you
     ///     will need to load the existing tilesets (tilea and tileas) from the archive and append this tileset to the existing
@@ -185,7 +189,9 @@ public sealed class Tileset : Collection<Tile>, ISavable
     /// ]]>
     /// </code>
     /// </example>
-    /// <exception cref="InvalidDataException">Thrown if any of the images has a size different than CONSTANTS.TILE_SIZE.</exception>
+    /// <exception cref="InvalidDataException">
+    ///     Thrown if any of the images has a size different than CONSTANTS.TILE_SIZE.
+    /// </exception>
     public static Palettized<Tileset> FromImages(params SKImage[] images)
     {
         if (images.Any(img => (img.Height * img.Width) != CONSTANTS.TILE_SIZE))
@@ -215,8 +221,12 @@ public sealed class Tileset : Collection<Tile>, ISavable
     /// <summary>
     ///     Loads a Tileset with the specified fileName from the specified archive
     /// </summary>
-    /// <param name="fileName">The name of the Tileset to search for in the archive.</param>
-    /// <param name="archive">The DataArchive from which to retreive the Tileset from</param>
+    /// <param name="fileName">
+    ///     The name of the Tileset to search for in the archive.
+    /// </param>
+    /// <param name="archive">
+    ///     The DataArchive from which to retreive the Tileset from
+    /// </param>
     public static Tileset FromArchive(string fileName, DataArchive archive)
     {
         if (!archive.TryGetValue(fileName.WithExtension(".bmp"), out var entry))
@@ -228,7 +238,9 @@ public sealed class Tileset : Collection<Tile>, ISavable
     /// <summary>
     ///     Loads a Tileset from the specified archive entry
     /// </summary>
-    /// <param name="entry">The DataArchiveEntry to load the TileSet from</param>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to load the TileSet from
+    /// </param>
     public static Tileset FromEntry(DataArchiveEntry entry)
     {
         using var segment = entry.ToStreamSegment();
@@ -239,7 +251,9 @@ public sealed class Tileset : Collection<Tile>, ISavable
     /// <summary>
     ///     Loads an TileSet from the specified path
     /// </summary>
-    /// <param name="path">The path of the file to be read.</param>
+    /// <param name="path">
+    ///     The path of the file to be read.
+    /// </param>
     public static Tileset FromFile(string path)
     {
         using var stream = File.Open(

--- a/DALib/Extensions/BinaryReaderExtensions.cs
+++ b/DALib/Extensions/BinaryReaderExtensions.cs
@@ -13,9 +13,15 @@ public static class BinaryReaderExtensions
     /// <summary>
     ///     Reads a 16-bit signed short from the current stream and advances the position of the stream by two bytes
     /// </summary>
-    /// <param name="reader">The BinaryReader from which to read the short.</param>
-    /// <param name="bigEndian">A boolean flag indicating whether the short should be read in big-endian format.</param>
-    /// <returns>A 16-bit signed integer read from the stream.</returns>
+    /// <param name="reader">
+    ///     The BinaryReader from which to read the short.
+    /// </param>
+    /// <param name="bigEndian">
+    ///     A boolean flag indicating whether the short should be read in big-endian format.
+    /// </param>
+    /// <returns>
+    ///     A 16-bit signed integer read from the stream.
+    /// </returns>
     public static short ReadInt16(this BinaryReader reader, bool bigEndian)
     {
         if (!bigEndian)
@@ -29,8 +35,12 @@ public static class BinaryReaderExtensions
     /// <summary>
     ///     Reads a 32-bit signed integer from the current stream and advances the position by four bytes.
     /// </summary>
-    /// <param name="reader">The BinaryReader to read from.</param>
-    /// <param name="bigEndian">A boolean flag indicating whether the integer should be read in big-endian format.</param>
+    /// <param name="reader">
+    ///     The BinaryReader to read from.
+    /// </param>
+    /// <param name="bigEndian">
+    ///     A boolean flag indicating whether the integer should be read in big-endian format.
+    /// </param>
     /// <returns>
     ///     The 32-bit signed integer read from the current stream
     /// </returns>
@@ -47,7 +57,9 @@ public static class BinaryReaderExtensions
     /// <summary>
     ///     Reads a 16-bit color value encoded as RGB555 from the specified BinaryReader and scales it to RGB888
     /// </summary>
-    /// <param name="reader">The BinaryReader to read from.</param>
+    /// <param name="reader">
+    ///     The BinaryReader to read from.
+    /// </param>
     /// <remarks>
     ///     The color is read as an RGB555 encoded color, then scaled to RGB888 and stored as an SKColor
     /// </remarks>
@@ -56,7 +68,9 @@ public static class BinaryReaderExtensions
     /// <summary>
     ///     Reads a 16-bit color value encoded as RGB565 from the specified BinaryReader and scales it to RGB888
     /// </summary>
-    /// <param name="reader">The BinaryReader to read from.</param>
+    /// <param name="reader">
+    ///     The BinaryReader to read from.
+    /// </param>
     /// <remarks>
     ///     The color is read as an RGB565 encoded color, then scaled to RGB888 and stored as an SKColor
     /// </remarks>
@@ -65,9 +79,15 @@ public static class BinaryReaderExtensions
     /// <summary>
     ///     Reads a string from the BinaryReader
     /// </summary>
-    /// <param name="reader">The BinaryReader to read from.</param>
-    /// <param name="encoding">The encoding used to decode the string.</param>
-    /// <param name="bigEndian">A boolean flag indicating whether the length prefix should be read in big-endian format.</param>
+    /// <param name="reader">
+    ///     The BinaryReader to read from.
+    /// </param>
+    /// <param name="encoding">
+    ///     The encoding used to decode the string.
+    /// </param>
+    /// <param name="bigEndian">
+    ///     A boolean flag indicating whether the length prefix should be read in big-endian format.
+    /// </param>
     public static string ReadString16(this BinaryReader reader, Encoding encoding, bool bigEndian)
     {
         var length = reader.ReadUInt16(bigEndian);
@@ -79,8 +99,12 @@ public static class BinaryReaderExtensions
     /// <summary>
     ///     Reads a string from the BinaryReader
     /// </summary>
-    /// <param name="reader">The BinaryReader to read from.</param>
-    /// <param name="encoding">The encoding used to decode the string.</param>
+    /// <param name="reader">
+    ///     The BinaryReader to read from.
+    /// </param>
+    /// <param name="encoding">
+    ///     The encoding used to decode the string.
+    /// </param>
     public static string ReadString8(this BinaryReader reader, Encoding encoding)
     {
         var length = reader.ReadByte();
@@ -92,9 +116,15 @@ public static class BinaryReaderExtensions
     /// <summary>
     ///     Reads a 16-bit unsigned short from the current stream and advances the position of the stream by two bytes
     /// </summary>
-    /// <param name="reader">The BinaryReader from which to read the short.</param>
-    /// <param name="bigEndian">A boolean flag indicating whether the short should be read in big-endian format.</param>
-    /// <returns>A 16-bit unsigned integer read from the stream.</returns>
+    /// <param name="reader">
+    ///     The BinaryReader from which to read the short.
+    /// </param>
+    /// <param name="bigEndian">
+    ///     A boolean flag indicating whether the short should be read in big-endian format.
+    /// </param>
+    /// <returns>
+    ///     A 16-bit unsigned integer read from the stream.
+    /// </returns>
     public static ushort ReadUInt16(this BinaryReader reader, bool bigEndian)
     {
         if (!bigEndian)
@@ -108,8 +138,12 @@ public static class BinaryReaderExtensions
     /// <summary>
     ///     Reads a 32-bit unsigned integer from the current stream and advances the position by four bytes.
     /// </summary>
-    /// <param name="reader">The BinaryReader to read from.</param>
-    /// <param name="bigEndian">A boolean flag indicating whether the integer should be read in big-endian format.</param>
+    /// <param name="reader">
+    ///     The BinaryReader to read from.
+    /// </param>
+    /// <param name="bigEndian">
+    ///     A boolean flag indicating whether the integer should be read in big-endian format.
+    /// </param>
     /// <returns>
     ///     The 32-bit unsigned integer read from the current stream
     /// </returns>

--- a/DALib/Extensions/BinaryWriterExtensions.cs
+++ b/DALib/Extensions/BinaryWriterExtensions.cs
@@ -12,8 +12,12 @@ public static class BinaryWriterExtensions
     /// <summary>
     ///     Writes an RGB888 color encoded as RGB555 to the BinaryWriter.
     /// </summary>
-    /// <param name="writer">The BinaryWriter to write to.</param>
-    /// <param name="color">An SKColor (RGB888)</param>
+    /// <param name="writer">
+    ///     The BinaryWriter to write to.
+    /// </param>
+    /// <param name="color">
+    ///     An SKColor (RGB888)
+    /// </param>
     public static void WriteRgb555Color(this BinaryWriter writer, SKColor color)
     {
         var encodedColor = ColorCodec.EncodeRgb555(color);
@@ -24,8 +28,12 @@ public static class BinaryWriterExtensions
     /// <summary>
     ///     Writes an RGB888 color encoded as RGB565 to the BinaryWriter.
     /// </summary>
-    /// <param name="writer">The BinaryWriter to write to.</param>
-    /// <param name="color">An SKColor (RGB888)</param>
+    /// <param name="writer">
+    ///     The BinaryWriter to write to.
+    /// </param>
+    /// <param name="color">
+    ///     An SKColor (RGB888)
+    /// </param>
     public static void WriteRgb565Color(this BinaryWriter writer, SKColor color)
     {
         var encodedColor = ColorCodec.EncodeRgb565(color);

--- a/DALib/Extensions/DictionaryExtensions.cs
+++ b/DALib/Extensions/DictionaryExtensions.cs
@@ -12,6 +12,8 @@ public static class DictionaryExtensions
     /// <summary>
     ///     Get the next available palette ID based on the keys of the given dictionary.
     /// </summary>
-    /// <param name="palettes">The dictionary containing the palettes</param>
+    /// <param name="palettes">
+    ///     The dictionary containing the palettes
+    /// </param>
     public static int GetNextPaletteId(this Dictionary<int, Palette> palettes) => palettes.Keys.Max() + 1;
 }

--- a/DALib/Extensions/KGPaletteExtensions.cs
+++ b/DALib/Extensions/KGPaletteExtensions.cs
@@ -13,7 +13,9 @@ public static class KGPaletteExtensions
     /// <summary>
     ///     Converts a KGPalette to a DALib.Palette
     /// </summary>
-    /// <param name="palette">The KGPalette to convert.</param>
+    /// <param name="palette">
+    ///     The KGPalette to convert.
+    /// </param>
     public static Palette ToDALibPalette(this KGPalette palette)
     {
         var orderedColors = palette.GetEntries()

--- a/DALib/Extensions/PalettizedExtensions.cs
+++ b/DALib/Extensions/PalettizedExtensions.cs
@@ -15,11 +15,14 @@ public static class PalettizedExtensions
     ///     For EPF images that are for a game type that supports dye colors, this method will arrange the colors in the
     ///     palette so that dye colors line up with the starting dye index
     /// </summary>
-    /// <param name="palettized">A palettized epf file</param>
+    /// <param name="palettized">
+    ///     A palettized epf file
+    /// </param>
     /// <param name="defaultDyeColors">
     ///     The dye colors present in the image. Set this to null if the type is dyeable, but the specific image is not
     /// </param>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="InvalidOperationException">
+    /// </exception>
     /// <remarks>
     ///     If the type is dyeable, but the specific image is not intended to be dyeable, make sure you specify only 250 colors
     ///     during quantization, so that there is room for the 6 dyeable color slots to be empty

--- a/DALib/Extensions/SKColorExtensions.cs
+++ b/DALib/Extensions/SKColorExtensions.cs
@@ -12,15 +12,21 @@ public static class SKColorExtensions
     /// <summary>
     ///     Calculates the luminance of a color using the provided coefficient.
     /// </summary>
-    /// <param name="color">The color whose luminance is being calculated.</param>
-    /// <param name="coefficient">The coefficient to multiply the luminance by. Default value is 1.0f.</param>
+    /// <param name="color">
+    ///     The color whose luminance is being calculated.
+    /// </param>
+    /// <param name="coefficient">
+    ///     The coefficient to multiply the luminance by. Default value is 1.0f.
+    /// </param>
     public static float GetLuminance(this SKColor color, float coefficient = 1.0f)
         => (0.299f * color.Red + 0.587f * color.Green + 0.114f * color.Blue) * coefficient;
 
     /// <summary>
     ///     Checks if a color is close to black
     /// </summary>
-    /// <param name="color">The color to check</param>
+    /// <param name="color">
+    ///     The color to check
+    /// </param>
     public static bool IsNearBlack(this SKColor color)
         => color is
         {
@@ -33,9 +39,15 @@ public static class SKColorExtensions
     /// <summary>
     ///     Returns a new SKColor with the alpha set based on the luminance of the color
     /// </summary>
-    /// <param name="color">An SKColor</param>
-    /// <param name="coefficient">The coefficient to multiply the luminance alpha by. Default value is 1.0f.</param>
-    /// <returns>A new SKColor with the alpha set.</returns>
+    /// <param name="color">
+    ///     An SKColor
+    /// </param>
+    /// <param name="coefficient">
+    ///     The coefficient to multiply the luminance alpha by. Default value is 1.0f.
+    /// </param>
+    /// <returns>
+    ///     A new SKColor with the alpha set.
+    /// </returns>
     public static SKColor WithLuminanceAlpha(this SKColor color, float coefficient = 1.0f)
     {
         var luminance = color.GetLuminance(coefficient);

--- a/DALib/Extensions/SKImageExtensions.cs
+++ b/DALib/Extensions/SKImageExtensions.cs
@@ -13,8 +13,12 @@ public static class SKImageExtensions
     /// <summary>
     ///     Retrieves the pixel data from an SKImage encoded as palette indexes pointing to the provided palette
     /// </summary>
-    /// <param name="image">The SKImage to retrieve the pixel data from.</param>
-    /// <param name="palette">A palette containing all of the colors in the image</param>
+    /// <param name="image">
+    ///     The SKImage to retrieve the pixel data from.
+    /// </param>
+    /// <param name="palette">
+    ///     A palette containing all of the colors in the image
+    /// </param>
     public static byte[] GetPalettizedPixelData(this SKImage image, Palette palette)
     {
         var colorMap = palette.Select((c, i) => (c, i))

--- a/DALib/Extensions/SpanReaderExtensions.cs
+++ b/DALib/Extensions/SpanReaderExtensions.cs
@@ -12,12 +12,16 @@ public static class SpanReaderExtensions
     /// <summary>
     ///     Reads a 16-bit RGB555 color from the SpanReader and scales it to RGB888
     /// </summary>
-    /// <param name="reader">The SpanReader instance.</param>
+    /// <param name="reader">
+    ///     The SpanReader instance.
+    /// </param>
     public static SKColor ReadRgb555Color(ref this SpanReader reader) => ColorCodec.DecodeRgb555(reader.ReadUInt16());
 
     /// <summary>
     ///     Reads a 16-bit RGB565 color from the SpanReader and scales it to RGB888
     /// </summary>
-    /// <param name="reader">The SpanReader instance.</param>
+    /// <param name="reader">
+    ///     The SpanReader instance.
+    /// </param>
     public static SKColor ReadRgb565Color(ref this SpanReader reader) => ColorCodec.DecodeRgb565(reader.ReadUInt16());
 }

--- a/DALib/Extensions/SpanWriterExtensions.cs
+++ b/DALib/Extensions/SpanWriterExtensions.cs
@@ -11,8 +11,12 @@ public static class SpanWriterExtensions
     /// <summary>
     ///     Writes the given SKColor as a 16-bit RGB555 encoded color to the SpanWriter.
     /// </summary>
-    /// <param name="writer">The SpanWriter to write the color to.</param>
-    /// <param name="color">The RGB888 color to encode and write</param>
+    /// <param name="writer">
+    ///     The SpanWriter to write the color to.
+    /// </param>
+    /// <param name="color">
+    ///     The RGB888 color to encode and write
+    /// </param>
     public static void WriteRgb555Color(ref this SpanWriter writer, SKColor color)
     {
         var r = color.Red >> 3;
@@ -27,8 +31,12 @@ public static class SpanWriterExtensions
     /// <summary>
     ///     Writes the given SKColor as a 16-bit RGB565 encoded color to the SpanWriter.
     /// </summary>
-    /// <param name="writer">The SpanWriter to write the color to.</param>
-    /// <param name="color">The RGB888 color to encode and write</param>
+    /// <param name="writer">
+    ///     The SpanWriter to write the color to.
+    /// </param>
+    /// <param name="color">
+    ///     The RGB888 color to encode and write
+    /// </param>
     public static void WriteRgb565Color(ref this SpanWriter writer, SKColor color)
     {
         var r = color.Red >> 3;

--- a/DALib/Extensions/StreamExtensions.cs
+++ b/DALib/Extensions/StreamExtensions.cs
@@ -12,13 +12,28 @@ public static class StreamExtensions
     /// <summary>
     ///     Returns a slice of the original stream, starting from the specified offset and with the specified length.
     /// </summary>
-    /// <param name="stream">The original stream.</param>
-    /// <param name="offset">The starting position of the slice.</param>
-    /// <param name="length">The length of the slice.</param>
+    /// <param name="stream">
+    ///     The original stream.
+    /// </param>
+    /// <param name="offset">
+    ///     The starting position of the slice.
+    /// </param>
+    /// <param name="length">
+    ///     The length of the slice.
+    /// </param>
     /// <param name="leaveOpen">
-    ///     <c>true</c> to leave the original stream open when the slice is disposed;
-    ///     <c>false</c> to close it.
-    ///     Default is <c>true</c>.
+    ///     <c>
+    ///         true
+    ///     </c>
+    ///     to leave the original stream open when the slice is disposed;
+    ///     <c>
+    ///         false
+    ///     </c>
+    ///     to close it. Default is
+    ///     <c>
+    ///         true
+    ///     </c>
+    ///     .
     /// </param>
     /// <remarks>
     ///     This creates a <see cref="StreamSegment" /> that wraps the original stream. This segment can not be used
@@ -38,7 +53,9 @@ public static class StreamExtensions
     /// <summary>
     ///     Reads the remaining data from the stream and returns it as a byte array
     /// </summary>
-    /// <param name="stream">The stream to convert.</param>
+    /// <param name="stream">
+    ///     The stream to convert.
+    /// </param>
     public static byte[] ToArray(this Stream stream)
     {
         if (stream is MemoryStream memoryStream)
@@ -53,7 +70,9 @@ public static class StreamExtensions
     /// <summary>
     ///     Reads the remaining data from the stream and returns it as a span of bytes
     /// </summary>
-    /// <param name="stream">The stream to convert.</param>
+    /// <param name="stream">
+    ///     The stream to convert.
+    /// </param>
     public static Span<byte> ToSpan(this Stream stream)
     {
         var buffer = new Span<byte>(new byte[stream.Length - stream.Position]);

--- a/DALib/Extensions/StringExtensions.cs
+++ b/DALib/Extensions/StringExtensions.cs
@@ -11,12 +11,16 @@ public static class StringExtensions
     /// <summary>
     ///     Adds or replaces the file extension of a given string with a new extension.
     /// </summary>
-    /// <param name="str">The string to modify.</param>
-    /// <param name="extension">The new extension to add or replace.</param>
+    /// <param name="str">
+    ///     The string to modify.
+    /// </param>
+    /// <param name="extension">
+    ///     The new extension to add or replace.
+    /// </param>
     /// <returns>
-    ///     The modified string with the new extension. If the original string does not have
-    ///     an extension, the new extension will be appended to it. If the original string
-    ///     already has an extension, it will be replaced with the new extension.
+    ///     The modified string with the new extension. If the original string does not have an extension, the new extension
+    ///     will be appended to it. If the original string already has an extension, it will be replaced with the new
+    ///     extension.
     /// </returns>
     /// <remarks>
     ///     The provided extension can omit or include the leading dot

--- a/DALib/IO/Compression.cs
+++ b/DALib/IO/Compression.cs
@@ -10,7 +10,9 @@ public static class Compression
     /// <summary>
     ///     Decompresses HPF data in-place.
     /// </summary>
-    /// <param name="buffer">The buffer containing the HPF data to decompress.</param>
+    /// <param name="buffer">
+    ///     The buffer containing the HPF data to decompress.
+    /// </param>
     public static void DecompressHpf(ref Span<byte> buffer)
     {
         // method written by Eru/illuvatar

--- a/DALib/IO/StreamSegment.cs
+++ b/DALib/IO/StreamSegment.cs
@@ -50,10 +50,18 @@ public class StreamSegment : Stream
     /// <summary>
     ///     Initializes a new instance of the <see cref="StreamSegment" /> class.
     /// </summary>
-    /// <param name="baseStream">The base stream.</param>
-    /// <param name="offset">The offset within the base stream where the segment starts.</param>
-    /// <param name="segmentLength">The length of the segment.</param>
-    /// <param name="leaveOpen">Whether to leave the base stream open when disposing the segment.</param>
+    /// <param name="baseStream">
+    ///     The base stream.
+    /// </param>
+    /// <param name="offset">
+    ///     The offset within the base stream where the segment starts.
+    /// </param>
+    /// <param name="segmentLength">
+    ///     The length of the segment.
+    /// </param>
+    /// <param name="leaveOpen">
+    ///     Whether to leave the base stream open when disposing the segment.
+    /// </param>
     public StreamSegment(
         Stream baseStream,
         long offset,
@@ -79,7 +87,7 @@ public class StreamSegment : Stream
     }
 
     /// <inheritdoc />
-    public override void Flush() { BaseStream.Flush(); }
+    public override void Flush() => BaseStream.Flush();
 
     /// <inheritdoc />
     public override int Read(byte[] buffer, int offset, int count)
@@ -113,12 +121,12 @@ public class StreamSegment : Stream
     }
 
     /// <inheritdoc />
-    public override void SetLength(long value) { throw new NotImplementedException(); }
+    public override void SetLength(long value) => throw new NotImplementedException();
 
     /// <summary>
     ///     Updates the current position of the segment based on the base stream's position.
     /// </summary>
-    protected virtual void SetPositionFromBaseStream() { Position = BaseStream.Position - BaseOffset; }
+    protected virtual void SetPositionFromBaseStream() => Position = BaseStream.Position - BaseOffset;
 
     /// <inheritdoc />
     public override void Write(byte[] buffer, int offset, int count)

--- a/DALib/IO/StreamSegment.cs
+++ b/DALib/IO/StreamSegment.cs
@@ -134,6 +134,9 @@ public class StreamSegment : Stream
         if (BaseStream.Position != OffsetPosition)
             BaseStream.Seek(OffsetPosition, SeekOrigin.Begin);
 
+        if ((Position + count) > Length)
+            throw new ArgumentOutOfRangeException(nameof(count), count, null);
+
         BaseStream.Write(buffer, offset, count);
 
         SetPositionFromBaseStream();

--- a/DALib/Memory/SpanReader.cs
+++ b/DALib/Memory/SpanReader.cs
@@ -44,9 +44,15 @@ public ref struct SpanReader
     /// <summary>
     ///     Initializes a new instance of the <see cref="SpanReader" /> struct.
     /// </summary>
-    /// <param name="encoding">The encoding to use for string operations.</param>
-    /// <param name="buffer">The span of bytes to read from.</param>
-    /// <param name="endianness">The endianness of the data (default is BigEndian).</param>
+    /// <param name="encoding">
+    ///     The encoding to use for string operations.
+    /// </param>
+    /// <param name="buffer">
+    ///     The span of bytes to read from.
+    /// </param>
+    /// <param name="endianness">
+    ///     The endianness of the data (default is BigEndian).
+    /// </param>
     public SpanReader(Encoding encoding, in Span<byte> buffer, Endianness endianness = Endianness.BigEndian)
     {
         Buffer = buffer;
@@ -197,8 +203,7 @@ public ref struct SpanReader
 
     /// <summary>
     ///     Reads a string separated ending with a null terminator from the current position in the Span, or the rest of the
-    ///     Span if no null
-    ///     terminator is found.
+    ///     Span if no null terminator is found.
     /// </summary>
     public string ReadString()
     {

--- a/DALib/Memory/SpanWriter.cs
+++ b/DALib/Memory/SpanWriter.cs
@@ -45,9 +45,15 @@ public ref struct SpanWriter
     /// <summary>
     ///     Initializes a new instance of the <see cref="SpanWriter" /> struct with the specified encoding and buffer.
     /// </summary>
-    /// <param name="encoding">The encoding used for writing strings.</param>
-    /// <param name="buffer">A reference to the buffer.</param>
-    /// <param name="endianness">The endianness used for writing numbers.</param>
+    /// <param name="encoding">
+    ///     The encoding used for writing strings.
+    /// </param>
+    /// <param name="buffer">
+    ///     A reference to the buffer.
+    /// </param>
+    /// <param name="endianness">
+    ///     The endianness used for writing numbers.
+    /// </param>
     public SpanWriter(Encoding encoding, ref Span<byte> buffer, Endianness endianness = Endianness.BigEndian)
     {
         Buffer = buffer;
@@ -62,10 +68,18 @@ public ref struct SpanWriter
     ///     Initializes a new instance of the <see cref="SpanWriter" /> struct with the specified encoding, initial buffer
     ///     size, and endianness.
     /// </summary>
-    /// <param name="encoding">The encoding used for writing strings.</param>
-    /// <param name="initialBufferSize">The initial size of the buffer.</param>
-    /// <param name="autoGrow">A flag indicating whether the buffer should automatically grow when needed.</param>
-    /// <param name="endianness">The endianness used for writing numbers.</param>
+    /// <param name="encoding">
+    ///     The encoding used for writing strings.
+    /// </param>
+    /// <param name="initialBufferSize">
+    ///     The initial size of the buffer.
+    /// </param>
+    /// <param name="autoGrow">
+    ///     A flag indicating whether the buffer should automatically grow when needed.
+    /// </param>
+    /// <param name="endianness">
+    ///     The endianness used for writing numbers.
+    /// </param>
     public SpanWriter(
         Encoding encoding,
         int initialBufferSize = 50,
@@ -83,7 +97,7 @@ public ref struct SpanWriter
     /// <summary>
     ///     Trims the buffer to the current position.
     /// </summary>
-    public void Flush() { Buffer = Buffer[..Position]; }
+    public void Flush() => Buffer = Buffer[..Position];
 
     private void GrowIfNeeded(int bytesToWrite)
     {
@@ -118,7 +132,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Returns a trimmed span of the underlying buffer.
     /// </summary>
-    /// <returns>The trimmed span of the underlying buffer.</returns>
+    /// <returns>
+    ///     The trimmed span of the underlying buffer.
+    /// </returns>
     public Span<byte> ToSpan()
     {
         if (Buffer.Length != Position)
@@ -130,8 +146,12 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a value of a numeric type to the buffer.
     /// </summary>
-    /// <typeparam name="T">The numeric type of the value to write.</typeparam>
-    /// <param name="value">The value to write.</param>
+    /// <typeparam name="T">
+    ///     The numeric type of the value to write.
+    /// </typeparam>
+    /// <param name="value">
+    ///     The value to write.
+    /// </param>
     public void WriteValue<T>(T value) where T: unmanaged
     {
         switch (value)
@@ -178,7 +198,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a boolean value to the buffer.
     /// </summary>
-    /// <param name="value">The boolean value to write.</param>
+    /// <param name="value">
+    ///     The boolean value to write.
+    /// </param>
     public void WriteBoolean(bool value)
     {
         GrowIfNeeded(sizeof(bool));
@@ -191,7 +213,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a byte value to the buffer.
     /// </summary>
-    /// <param name="value">The byte value to write.</param>
+    /// <param name="value">
+    ///     The byte value to write.
+    /// </param>
     public void WriteByte(byte value)
     {
         GrowIfNeeded(1);
@@ -202,7 +226,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes an array of bytes to the buffer.
     /// </summary>
-    /// <param name="buffer">The byte array to write.</param>
+    /// <param name="buffer">
+    ///     The byte array to write.
+    /// </param>
     public void WriteBytes(params byte[] buffer)
     {
         GrowIfNeeded(buffer.Length);
@@ -214,8 +240,12 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a byte array to the buffer with an optional line feed.
     /// </summary>
-    /// <param name="buffer">The byte array to write.</param>
-    /// <param name="lineFeed">A flag indicating whether to append a line feed after the byte array.</param>
+    /// <param name="buffer">
+    ///     The byte array to write.
+    /// </param>
+    /// <param name="lineFeed">
+    ///     A flag indicating whether to append a line feed after the byte array.
+    /// </param>
     public void WriteData(byte[] buffer, bool lineFeed = false)
     {
         WriteBytes(buffer);
@@ -227,7 +257,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a byte array with a prepended 16-bit length to the buffer.
     /// </summary>
-    /// <param name="buffer">The byte array to write.</param>
+    /// <param name="buffer">
+    ///     The byte array to write.
+    /// </param>
     public void WriteData16(byte[] buffer)
     {
         if (buffer.Length > ushort.MaxValue)
@@ -240,7 +272,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a byte array with a prepended 8-bit length to the buffer.
     /// </summary>
-    /// <param name="buffer">The byte array to write.</param>
+    /// <param name="buffer">
+    ///     The byte array to write.
+    /// </param>
     public void WriteData8(byte[] buffer)
     {
         if (buffer.Length > byte.MaxValue)
@@ -253,7 +287,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a 16-bit signed integer value to the buffer.
     /// </summary>
-    /// <param name="value">The 16-bit signed integer value to write.</param>
+    /// <param name="value">
+    ///     The 16-bit signed integer value to write.
+    /// </param>
     public void WriteInt16(short value)
     {
         GrowIfNeeded(sizeof(short));
@@ -268,7 +304,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a 32-bit signed integer value to the buffer.
     /// </summary>
-    /// <param name="value">The 32-bit signed integer value to write.</param>
+    /// <param name="value">
+    ///     The 32-bit signed integer value to write.
+    /// </param>
     public void WriteInt32(int value)
     {
         GrowIfNeeded(sizeof(int));
@@ -283,8 +321,12 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes two 16-bit unsigned integers as a point to the buffer.
     /// </summary>
-    /// <param name="x">The x-coordinate of the point.</param>
-    /// <param name="y">The y-coordinate of the point.</param>
+    /// <param name="x">
+    ///     The x-coordinate of the point.
+    /// </param>
+    /// <param name="y">
+    ///     The y-coordinate of the point.
+    /// </param>
     public void WritePoint16(ushort x, ushort y)
     {
         WriteUInt16(x);
@@ -296,8 +338,12 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes two 8-bit unsigned integers as a point to the buffer.
     /// </summary>
-    /// <param name="x">The x-coordinate of the point.</param>
-    /// <param name="y">The y-coordinate of the point.</param>
+    /// <param name="x">
+    ///     The x-coordinate of the point.
+    /// </param>
+    /// <param name="y">
+    ///     The y-coordinate of the point.
+    /// </param>
     public void WritePoint8(byte x, byte y)
     {
         WriteByte(x);
@@ -307,7 +353,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes an 8-bit signed byte value to the buffer.
     /// </summary>
-    /// <param name="value">The 8-bit signed integer value to write.</param>
+    /// <param name="value">
+    ///     The 8-bit signed integer value to write.
+    /// </param>
     public void WriteSByte(sbyte value)
     {
         GrowIfNeeded(sizeof(sbyte));
@@ -320,9 +368,15 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a string to the buffer with optional line feed or null termination.
     /// </summary>
-    /// <param name="value">The string to write.</param>
-    /// <param name="lineFeed">A flag indicating whether to append a line feed after the string.</param>
-    /// <param name="terminate">A flag indicating whether to append a null terminator after the string.</param>
+    /// <param name="value">
+    ///     The string to write.
+    /// </param>
+    /// <param name="lineFeed">
+    ///     A flag indicating whether to append a line feed after the string.
+    /// </param>
+    /// <param name="terminate">
+    ///     A flag indicating whether to append a null terminator after the string.
+    /// </param>
     public void WriteString(string value, bool lineFeed = false, bool terminate = false)
     {
         var buffer = Encoding.GetBytes(value);
@@ -332,7 +386,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a string with a prepended 16-bit length to the buffer.
     /// </summary>
-    /// <param name="value">The string to write.</param>
+    /// <param name="value">
+    ///     The string to write.
+    /// </param>
     public void WriteString16(string value)
     {
         var buffer = Encoding.GetBytes(value)
@@ -348,7 +404,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a string with a prepended 8-bit length to the buffer.
     /// </summary>
-    /// <param name="value">The string to write.</param>
+    /// <param name="value">
+    ///     The string to write.
+    /// </param>
     public void WriteString8(string value)
     {
         var buffer = Encoding.GetBytes(value)
@@ -364,7 +422,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a 16-bit unsigned integer value to the buffer.
     /// </summary>
-    /// <param name="value">The 16-bit unsigned integer value to write.</param>
+    /// <param name="value">
+    ///     The 16-bit unsigned integer value to write.
+    /// </param>
     public void WriteUInt16(ushort value)
     {
         GrowIfNeeded(sizeof(ushort));
@@ -379,7 +439,9 @@ public ref struct SpanWriter
     /// <summary>
     ///     Writes a 32-bit unsigned integer value to the buffer.
     /// </summary>
-    /// <param name="value">The 32-bit unsigned integer value to write.</param>
+    /// <param name="value">
+    ///     The 32-bit unsigned integer value to write.
+    /// </param>
     public void WriteUInt32(uint value)
     {
         GrowIfNeeded(sizeof(uint));

--- a/DALib/Utility/ColorCodec.cs
+++ b/DALib/Utility/ColorCodec.cs
@@ -11,7 +11,9 @@ public static class ColorCodec
     /// <summary>
     ///     Decodes a 16-bit encoded RGB555 color value into an SKColor and scales the color to RGB888
     /// </summary>
-    /// <param name="encodedColor">The 16-bit encoded RGB555 color value </param>
+    /// <param name="encodedColor">
+    ///     The 16-bit encoded RGB555 color value
+    /// </param>
     public static SKColor DecodeRgb555(ushort encodedColor)
     {
         var r = (byte)((encodedColor >> 10) & CONSTANTS.FIVE_BIT_MASK);
@@ -45,7 +47,9 @@ public static class ColorCodec
     /// <summary>
     ///     Decodes a 16-bit encoded RGB565 color value into an SKColor and scales the color to RGB888
     /// </summary>
-    /// <param name="encodedColor">The 16-bit encoded RGB555 color value </param>
+    /// <param name="encodedColor">
+    ///     The 16-bit encoded RGB555 color value
+    /// </param>
     public static SKColor DecodeRgb565(ushort encodedColor)
     {
         var r = (byte)(encodedColor >> 11);
@@ -79,7 +83,9 @@ public static class ColorCodec
     /// <summary>
     ///     Encodes an SKColor into a 16 bit RGB555 encoded color
     /// </summary>
-    /// <param name="color">The SKColor to encode.</param>
+    /// <param name="color">
+    ///     The SKColor to encode.
+    /// </param>
     public static ushort EncodeRgb555(SKColor color)
     {
         var r = MathEx.ScaleRange<byte, byte>(
@@ -109,7 +115,9 @@ public static class ColorCodec
     /// <summary>
     ///     Encodes an SKColor into a 16 bit RGB565 encoded color
     /// </summary>
-    /// <param name="color">The SKColor to encode.</param>
+    /// <param name="color">
+    ///     The SKColor to encode.
+    /// </param>
     public static ushort EncodeRgb565(SKColor color)
     {
         var r = MathEx.ScaleRange<byte, byte>(

--- a/DALib/Utility/ControlFileParser.cs
+++ b/DALib/Utility/ControlFileParser.cs
@@ -121,8 +121,12 @@ public sealed class ControlFileParser
     /// <summary>
     ///     Parses Controls from a stream, adding them to the specified controlFile
     /// </summary>
-    /// <param name="controlFile">The control file object to populate with data.</param>
-    /// <param name="stream">The stream containing the control file data.</param>
+    /// <param name="controlFile">
+    ///     The control file object to populate with data.
+    /// </param>
+    /// <param name="stream">
+    ///     The stream containing the control file data.
+    /// </param>
     public void Parse(ControlFile controlFile, Stream stream)
     {
         using var reader = new StreamReader(stream, leaveOpen: true);

--- a/DALib/Utility/Helpers.cs
+++ b/DALib/Utility/Helpers.cs
@@ -1,0 +1,12 @@
+using System.Runtime.InteropServices;
+
+namespace DALib.Utility;
+
+internal static class Helpers
+{
+    internal static void FreeHandle(nint address, object context)
+    {
+        var handle = (GCHandle)context;
+        handle.Free();
+    }
+}

--- a/DALib/Utility/ImageProcessor.cs
+++ b/DALib/Utility/ImageProcessor.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using DALib.Definitions;
 using DALib.Extensions;
 using KGySoft.Drawing.Imaging;
@@ -16,9 +17,15 @@ public static class ImageProcessor
     /// <summary>
     ///     Creates a mosaic image by combining multiple images horizontally.
     /// </summary>
-    /// <param name="colorType">The color type of the resulting mosaic image.</param>
-    /// <param name="padding">The padding between each image in pixels. Default value is 1.</param>
-    /// <param name="images">The images to be combined into a mosaic.</param>
+    /// <param name="colorType">
+    ///     The color type of the resulting mosaic image.
+    /// </param>
+    /// <param name="padding">
+    ///     The padding between each image in pixels. Default value is 1.
+    /// </param>
+    /// <param name="images">
+    ///     The images to be combined into a mosaic.
+    /// </param>
     public static SKImage CreateMosaic(SKColorType colorType, int padding = 1, params SKImage[] images)
     {
         var width = images.Sum(img => img.Width) + (images.Length - 1) * padding;
@@ -48,7 +55,9 @@ public static class ImageProcessor
     /// <summary>
     ///     Preserves non-transparent black pixels in the given image by converting them to a very dark gray (1, 1, 1)
     /// </summary>
-    /// <param name="image">The image whose black pixels to preserve</param>
+    /// <param name="image">
+    ///     The image whose black pixels to preserve
+    /// </param>
     public static void PreserveNonTransparentBlacks(SKImage image)
     {
         using var bitmap = SKBitmap.FromImage(image);
@@ -59,23 +68,29 @@ public static class ImageProcessor
     /// <summary>
     ///     Preserves non-transparent black pixels in the given image by converting them to a very dark gray (1, 1, 1)
     /// </summary>
-    /// <param name="bitmap">The image whose black pixels to preserve</param>
+    /// <param name="bitmap">
+    ///     The image whose black pixels to preserve
+    /// </param>
     public static void PreserveNonTransparentBlacks(SKBitmap bitmap)
     {
+        using var canvas = new SKCanvas(bitmap);
+
         for (var y = 0; y < bitmap.Height; y++)
             for (var x = 0; x < bitmap.Width; x++)
             {
                 var color = bitmap.GetPixel(x, y);
 
                 if (color.IsNearBlack())
-                    bitmap.SetPixel(x, y, CONSTANTS.RGB555_ALMOST_BLACK);
+                    canvas.DrawPoint(x, y, CONSTANTS.RGB555_ALMOST_BLACK);
             }
     }
 
     /// <summary>
     ///     Preserves non-transparent black pixels in the given images by converting them to a very dark gray (1, 1, 1)
     /// </summary>
-    /// <param name="images">The images whose black pixels to preserve</param>
+    /// <param name="images">
+    ///     The images whose black pixels to preserve
+    /// </param>
     public static void PreserveNonTransparentBlacks(IEnumerable<SKImage> images)
     {
         foreach (var image in images)
@@ -85,8 +100,12 @@ public static class ImageProcessor
     /// <summary>
     ///     Quantizes the given image using the specified quantizer options.
     /// </summary>
-    /// <param name="options">The quantizer options.</param>
-    /// <param name="image">The image to be quantized.</param>
+    /// <param name="options">
+    ///     The quantizer options.
+    /// </param>
+    /// <param name="image">
+    ///     The image to be quantized.
+    /// </param>
     /// <remarks>
     ///     Quantization is the process of reducing the number of colors in an image. This method uses the Wu algorithm
     /// </remarks>
@@ -98,6 +117,8 @@ public static class ImageProcessor
 
         using var qSession = quantizer.Initialize(source);
         using var quantizedBitmap = new SKBitmap(image.Info.WithColorType(options.ColorType));
+
+        var pixelBuffer = new SKColor[bitmap.Width * bitmap.Height];
 
         //if a ditherer was specified, use it
         if (options.Ditherer is not null)
@@ -112,7 +133,8 @@ public static class ImageProcessor
 
                     var ditheredColor = dSession.GetDitheredColor(color.ToColor32(), x, y)
                                                 .ToSKColor();
-                    quantizedBitmap.SetPixel(x, y, ditheredColor);
+
+                    pixelBuffer[y * image.Width + x] = ditheredColor;
                 }
             }
         } else //otherwise, just quantize the image
@@ -122,13 +144,19 @@ public static class ImageProcessor
                 {
                     var color = bitmap.GetPixel(x, y);
 
-                    quantizedBitmap.SetPixel(
-                        x,
-                        y,
-                        qSession.GetQuantizedColor(color.ToColor32())
-                                .ToSKColor());
+                    pixelBuffer[y * image.Width + x] = qSession.GetQuantizedColor(color.ToColor32())
+                                                               .ToSKColor();
                 }
             }
+
+        var handle = GCHandle.Alloc(pixelBuffer, GCHandleType.Pinned);
+
+        quantizedBitmap.InstallPixels(
+            quantizedBitmap.Info,
+            handle.AddrOfPinnedObject(),
+            quantizedBitmap.RowBytes,
+            Helpers.FreeHandle,
+            handle);
 
         var quantizedImage = SKImage.FromBitmap(quantizedBitmap);
 
@@ -142,8 +170,12 @@ public static class ImageProcessor
     /// <summary>
     ///     Quantizes the given images using the specified quantizer options
     /// </summary>
-    /// <param name="options">The quantizer options.</param>
-    /// <param name="images">The images to be quantized.</param>
+    /// <param name="options">
+    ///     The quantizer options.
+    /// </param>
+    /// <param name="images">
+    ///     The images to be quantized.
+    /// </param>
     /// <remarks>
     ///     Quantization is the process of reducing the number of colors in an image. This method uses the Wu algorithm. All
     ///     provided images will be quantized together so that the resulting palette is the same for all images

--- a/DALib/Utility/ImageProcessor.cs
+++ b/DALib/Utility/ImageProcessor.cs
@@ -17,25 +17,18 @@ public static class ImageProcessor
     /// <summary>
     ///     Creates a mosaic image by combining multiple images horizontally.
     /// </summary>
-    /// <param name="colorType">
-    ///     The color type of the resulting mosaic image.
-    /// </param>
     /// <param name="padding">
     ///     The padding between each image in pixels. Default value is 1.
     /// </param>
     /// <param name="images">
     ///     The images to be combined into a mosaic.
     /// </param>
-    public static SKImage CreateMosaic(SKColorType colorType, int padding = 1, params SKImage[] images)
+    public static SKImage CreateMosaic(int padding = 1, params SKImage[] images)
     {
         var width = images.Sum(img => img.Width) + (images.Length - 1) * padding;
         var height = images.Max(img => img.Height);
 
-        using var bitmap = new SKBitmap(
-            width,
-            height,
-            colorType,
-            SKAlphaType.Premul);
+        using var bitmap = new SKBitmap(width, height);
 
         using (var canvas = new SKCanvas(bitmap))
         {
@@ -116,9 +109,9 @@ public static class ImageProcessor
         var source = bitmap.GetReadableBitmapData();
 
         using var qSession = quantizer.Initialize(source);
-        using var quantizedBitmap = new SKBitmap(image.Info.WithColorType(options.ColorType));
+        using var quantizedBitmap = new SKBitmap(image.Info);
 
-        var pixelBuffer = new SKColor[bitmap.Width * bitmap.Height];
+        var pixelBuffer = new SKColor[quantizedBitmap.Width * quantizedBitmap.Height];
 
         //if a ditherer was specified, use it
         if (options.Ditherer is not null)
@@ -185,7 +178,7 @@ public static class ImageProcessor
         const int PADDING = 1;
 
         //create a mosaic of all of the individual images
-        using var mosaic = CreateMosaic(options.ColorType, PADDING, images);
+        using var mosaic = CreateMosaic(PADDING, images);
         using var quantizedMosaic = Quantize(options, mosaic);
         using var bitmap = SKBitmap.FromImage(quantizedMosaic.Entity);
 
@@ -195,7 +188,7 @@ public static class ImageProcessor
         for (var i = 0; i < images.Length; i++)
         {
             var originalImage = images[i];
-            using var quantizedBitmap = new SKBitmap(originalImage.Info.WithColorType(options.ColorType));
+            using var quantizedBitmap = new SKBitmap(originalImage.Info);
 
             //extract the quantized parts out of the mosaic
             bitmap.ExtractSubset(

--- a/DALib/Utility/MathEx.cs
+++ b/DALib/Utility/MathEx.cs
@@ -11,15 +11,26 @@ public static class MathEx
     /// <summary>
     ///     Scales a number from one range to another range.
     /// </summary>
-    /// <param name="num">The input number to be scaled.</param>
-    /// <param name="min">The lower bound of the original range.</param>
-    /// <param name="max">The upper bound of the original range.</param>
-    /// <param name="newMin">The lower bound of the new range.</param>
-    /// <param name="newMax">The upper bound of the new range.</param>
-    /// <returns>The scaled number in the new range.</returns>
+    /// <param name="num">
+    ///     The input number to be scaled.
+    /// </param>
+    /// <param name="min">
+    ///     The lower bound of the original range.
+    /// </param>
+    /// <param name="max">
+    ///     The upper bound of the original range.
+    /// </param>
+    /// <param name="newMin">
+    ///     The lower bound of the new range.
+    /// </param>
+    /// <param name="newMax">
+    ///     The upper bound of the new range.
+    /// </param>
+    /// <returns>
+    ///     The scaled number in the new range.
+    /// </returns>
     /// <remarks>
-    ///     This method assumes that the input number is within the original range.
-    ///     No clamping or checking is performed.
+    ///     This method assumes that the input number is within the original range. No clamping or checking is performed.
     /// </remarks>
     public static T2 ScaleRange<T1, T2>(
         T1 num,
@@ -39,15 +50,26 @@ public static class MathEx
     /// <summary>
     ///     Scales a number from one range to another range.
     /// </summary>
-    /// <param name="num">The input number to be scaled.</param>
-    /// <param name="min">The lower bound of the original range.</param>
-    /// <param name="max">The upper bound of the original range.</param>
-    /// <param name="newMin">The lower bound of the new range.</param>
-    /// <param name="newMax">The upper bound of the new range.</param>
-    /// <returns>The scaled number in the new range.</returns>
+    /// <param name="num">
+    ///     The input number to be scaled.
+    /// </param>
+    /// <param name="min">
+    ///     The lower bound of the original range.
+    /// </param>
+    /// <param name="max">
+    ///     The upper bound of the original range.
+    /// </param>
+    /// <param name="newMin">
+    ///     The lower bound of the new range.
+    /// </param>
+    /// <param name="newMax">
+    ///     The upper bound of the new range.
+    /// </param>
+    /// <returns>
+    ///     The scaled number in the new range.
+    /// </returns>
     /// <remarks>
-    ///     This method assumes that the input number is within the original range.
-    ///     No clamping or checking is performed.
+    ///     This method assumes that the input number is within the original range. No clamping or checking is performed.
     /// </remarks>
     public static double ScaleRange(
         double num,

--- a/DALib/Utility/Palettized.cs
+++ b/DALib/Utility/Palettized.cs
@@ -6,13 +6,17 @@ namespace DALib.Utility;
 /// <summary>
 ///     Represents a palettized object that associates an entity with a palette.
 /// </summary>
-/// <typeparam name="T">The type of the entity.</typeparam>
+/// <typeparam name="T">
+///     The type of the entity.
+/// </typeparam>
 public sealed class Palettized<T> : IDisposable
 {
     /// <summary>
     ///     The entity with which the palette is associated.
     /// </summary>
-    /// <typeparam name="T">The type of the Entity.</typeparam>
+    /// <typeparam name="T">
+    ///     The type of the Entity.
+    /// </typeparam>
     public required T Entity { get; init; }
 
     /// <summary>

--- a/DALib/Utility/QuantizerOptions.cs
+++ b/DALib/Utility/QuantizerOptions.cs
@@ -17,10 +17,14 @@ public sealed class QuantizerOptions
     /// <summary>
     ///     The default ditherer is null, but here are some possible options:
     ///     <br />
-    ///     "ErrorDiffusionDitherer.FloydSteinberg" <br />
-    ///     "new InterleavedGradientNoiseDitherer(AutoStrengthMode.Default)" <br />
-    ///     "OrderedDitherer.Bayer2x2", 3x3, or 4x4, <br />
-    ///     "ErrorDiffusionDitherer.Atkinson" <br />
+    ///     "ErrorDiffusionDitherer.FloydSteinberg"
+    ///     <br />
+    ///     "new InterleavedGradientNoiseDitherer(AutoStrengthMode.Default)"
+    ///     <br />
+    ///     "OrderedDitherer.Bayer2x2", 3x3, or 4x4,
+    ///     <br />
+    ///     "ErrorDiffusionDitherer.Atkinson"
+    ///     <br />
     /// </summary>
     /// <remarks>
     ///     The larger the matrix, the larger the spread of the error diffusion. This means the patterns used to dither the
@@ -50,9 +54,12 @@ public sealed class QuantizerOptions
     /// <summary>
     ///     The default ditherer is Floyd-Steinberg, but you can try out some of the others. Here are some other options:
     ///     <br />
-    ///     "new InterleavedGradientNoiseDitherer(AutoStrengthMode.Default)" <br />
-    ///     "OrderedDitherer.Bayer2x2", 3x3, or 4x4, <br />
-    ///     "ErrorDiffusionDitherer.Atkinson" <br />
+    ///     "new InterleavedGradientNoiseDitherer(AutoStrengthMode.Default)"
+    ///     <br />
+    ///     "OrderedDitherer.Bayer2x2", 3x3, or 4x4,
+    ///     <br />
+    ///     "ErrorDiffusionDitherer.Atkinson"
+    ///     <br />
     /// </summary>
     /// <remarks>
     ///     The larger the matrix, the larger the spread of the error diffusion. This means the patterns used to dither the

--- a/DALib/Utility/QuantizerOptions.cs
+++ b/DALib/Utility/QuantizerOptions.cs
@@ -1,6 +1,5 @@
 ﻿using DALib.Definitions;
 using KGySoft.Drawing.Imaging;
-using SkiaSharp;
 
 namespace DALib.Utility;
 
@@ -9,11 +8,6 @@ namespace DALib.Utility;
 /// </summary>
 public sealed class QuantizerOptions
 {
-    /// <summary>
-    ///     Do not change this value unless you know what you're doing
-    /// </summary>
-    public SKColorType ColorType { get; set; } = SKColorType.Rgba8888;
-
     /// <summary>
     ///     The default ditherer is null, but here are some possible options:
     ///     <br />

--- a/DALib/Utility/SKImageCache.cs
+++ b/DALib/Utility/SKImageCache.cs
@@ -7,7 +7,9 @@ namespace DALib.Utility;
 /// <summary>
 ///     Represents a disposable image cache that stores SKImage instances based on a generic key
 /// </summary>
-/// <typeparam name="TKey">The type of the cache key.</typeparam>
+/// <typeparam name="TKey">
+///     The type of the cache key.
+/// </typeparam>
 public class SKImageCache<TKey>(IEqualityComparer<TKey>? comparer = null) : IDisposable where TKey: IEquatable<TKey>
 {
     private readonly Dictionary<TKey, SKImage> Cache = new(comparer);
@@ -25,8 +27,12 @@ public class SKImageCache<TKey>(IEqualityComparer<TKey>? comparer = null) : IDis
     ///     Retrieves an existing SKImage for the specified key from the cache, or creates a new SKImage using the provided
     ///     create function and adds it to the cache.
     /// </summary>
-    /// <param name="key">The key used to retrieve or create the SKImage.</param>
-    /// <param name="create">The function used to create a new SKImage for the specified key.</param>
+    /// <param name="key">
+    ///     The key used to retrieve or create the SKImage.
+    /// </param>
+    /// <param name="create">
+    ///     The function used to create a new SKImage for the specified key.
+    /// </param>
     public virtual SKImage GetOrCreate(TKey key, Func<TKey, SKImage> create)
     {
         if (Cache.TryGetValue(key, out var image))


### PR DESCRIPTION
- replaced all instances of bitmap.SetPixel(), this was causing a massive slowdown
- now writing to a pixel buffer, pinning the reference of that buffer and setting the bitmap's pixel reference to that buffer
- added MemoryMappedDataArchive which utilizes MemoryMappedFile
- more formatting sry

approx 15x rendering performance