### PR TITLE
EffectTable / bugfixes / performance/ qol

### DIFF
--- a/DALib/Cryptography/CRC32.cs
+++ b/DALib/Cryptography/CRC32.cs
@@ -6,7 +6,7 @@
 public static class CRC32
 {
     private static readonly uint[] CRC32_TABLE =
-    {
+    [
         0x00000000,
         0x77073096,
         0xEE0E612C,
@@ -263,7 +263,7 @@ public static class CRC32
         0xC30C8EA1,
         0x5A05DF1B,
         0x2D02EF8D
-    };
+    ];
 
     /// <summary>
     ///     Calculates the 32bit checksum of the specified buffer

--- a/DALib/Data/DataArchiveEntry.cs
+++ b/DALib/Data/DataArchiveEntry.cs
@@ -7,7 +7,7 @@ namespace DALib.Data;
 /// <summary>
 ///     Represents an entry in a data archive.
 /// </summary>
-public sealed class DataArchiveEntry(
+public class DataArchiveEntry(
     DataArchive archive,
     string entryName,
     int address,

--- a/DALib/Data/PatchEntry.cs
+++ b/DALib/Data/PatchEntry.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using DALib.Abstractions;
+
+namespace DALib.Data;
+
+/// <summary>
+///     Represents an entry that can be used to patch a DataArchive without knowing it's underlying type
+/// </summary>
+public class PatchEntry : ISavable, IDisposable
+{
+    private readonly Stream SourceStream;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="PatchEntry" /> class
+    /// </summary>
+    /// <param name="stream">
+    ///     The stream containing the data of this entry
+    /// </param>
+    public PatchEntry(Stream stream) => SourceStream = stream;
+
+    /// <inheritdoc />
+    public void Dispose() => SourceStream.Dispose();
+
+    /// <inheritdoc />
+    public void Save(string path)
+    {
+        using var stream = File.Open(
+            path,
+            new FileStreamOptions
+            {
+                Access = FileAccess.Write,
+                Mode = FileMode.Create,
+                Options = FileOptions.SequentialScan,
+                Share = FileShare.ReadWrite
+            });
+
+        Save(stream);
+    }
+
+    /// <inheritdoc />
+    public void Save(Stream stream)
+    {
+        SourceStream.Seek(0, SeekOrigin.Begin);
+        SourceStream.CopyTo(stream);
+        SourceStream.Seek(0, SeekOrigin.Begin);
+    }
+}

--- a/DALib/Drawing/EffectTable.cs
+++ b/DALib/Drawing/EffectTable.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -13,7 +14,7 @@ namespace DALib.Drawing;
 /// </summary>
 public class EffectTable : ISavable
 {
-    private readonly List<List<int>> Entries = [];
+    private readonly List<EffectTableEntry> Entries = [];
 
     /// <summary>
     ///     Initializes a new instance of the EffectTable class.
@@ -53,7 +54,11 @@ public class EffectTable : ISavable
                 frameOrder.Add(frameIndex);
             }
 
-            Entries.Add(frameOrder);
+            var entry = new EffectTableEntry
+            {
+                FrameSequence = frameOrder
+            };
+            Entries.Add(entry);
         }
     }
 
@@ -63,12 +68,22 @@ public class EffectTable : ISavable
     /// <param name="frameOrder">
     ///     The frame order to add
     /// </param>
-    public void Add(IEnumerable<int> frameOrder) => Entries.Add(frameOrder.ToList());
+    public void Add(IEnumerable<int> frameOrder)
+        => Entries.Add(
+            new EffectTableEntry
+            {
+                FrameSequence = frameOrder.ToList()
+            });
 
     /// <summary>
     ///     Adds a new EFA frame order ("0") to the end of the table (effect number would be Entries.Count after the add)
     /// </summary>
-    public void AddEfa() => Entries.Add([0]);
+    public void AddEfa()
+        => Entries.Add(
+            new EffectTableEntry
+            {
+                FrameSequence = [0]
+            });
 
     /// <summary>
     ///     Gets the next available effect id
@@ -84,12 +99,26 @@ public class EffectTable : ISavable
     /// <param name="frameOrder">
     ///     The frame order for the effect
     /// </param>
-    public void Insert(int effectNum, IEnumerable<int> frameOrder) => Entries.Insert(effectNum - 1, frameOrder.ToList());
+    public void Insert(int effectNum, IEnumerable<int> frameOrder)
+    {
+        var entry = new EffectTableEntry
+        {
+            FrameSequence = frameOrder.ToList()
+        };
+        Entries.Insert(effectNum - 1, entry);
+    }
 
     /// <summary>
     ///     Inserts an EFA frame order ("0") for the specified effect number
     /// </summary>
-    public void InsertEfa() => Entries.Insert(0, [0]);
+    public void InsertEfa()
+    {
+        var entry = new EffectTableEntry
+        {
+            FrameSequence = [0]
+        };
+        Entries.Insert(0, entry);
+    }
 
     /// <summary>
     ///     Clears the frame order for the specified effect id
@@ -98,6 +127,29 @@ public class EffectTable : ISavable
     ///     The effect number to clear the frame order for. (1-indexed)
     /// </param>
     public void Remove(int effectNum) => Entries[effectNum - 1] = [];
+
+    /// <summary>
+    ///     Retrieves the frame order for the specified effect number
+    /// </summary>
+    /// <param name="effectId">
+    ///     The effect id to get the frame order for
+    /// </param>
+    /// <param name="entry">
+    ///     A table entry containing the frame order for the specified effect id
+    /// </param>
+    public bool TryGetEntry(int effectId, [NotNullWhen(true)] out EffectTableEntry? entry)
+    {
+        if ((effectId < 1) || (effectId > Entries.Count))
+        {
+            entry = default;
+
+            return false;
+        }
+
+        entry = Entries[effectId - 1];
+
+        return true;
+    }
 
     #region SaveTo
     /// <inheritdoc />

--- a/DALib/Drawing/EffectTable.cs
+++ b/DALib/Drawing/EffectTable.cs
@@ -1,0 +1,183 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using DALib.Abstractions;
+using DALib.Data;
+using DALib.Extensions;
+
+namespace DALib.Drawing;
+
+/// <summary>
+///     Represents a table of effect frame orders
+/// </summary>
+public class EffectTable : ISavable
+{
+    private readonly List<List<int>> Entries = [];
+
+    /// <summary>
+    ///     Initializes a new instance of the EffectTable class.
+    /// </summary>
+    public EffectTable() { }
+
+    private EffectTable(Stream stream)
+    {
+        using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        //effect count, but not rly important
+        if (!int.TryParse(reader.ReadLine(), out _))
+            return;
+
+        while (!reader.EndOfStream)
+        {
+            var line = reader.ReadLine();
+
+            if (string.IsNullOrEmpty(line))
+            {
+                Entries.Add([]);
+
+                continue;
+            }
+
+            var split = line.Split(' ');
+            var frameOrder = new List<int>();
+
+            for (var i = 0; i < split.Length; ++i)
+            {
+                var valueStr = split[i]
+                    .Trim();
+
+                if (!int.TryParse(valueStr, out var frameIndex))
+                    continue;
+
+                frameOrder.Add(frameIndex);
+            }
+
+            Entries.Add(frameOrder);
+        }
+    }
+
+    /// <summary>
+    ///     Adds a new frame order to the end of the table (effect number would be Entries.Count after the add)
+    /// </summary>
+    /// <param name="frameOrder">
+    ///     The frame order to add
+    /// </param>
+    public void Add(IEnumerable<int> frameOrder) => Entries.Add(frameOrder.ToList());
+
+    /// <summary>
+    ///     Adds a new EFA frame order ("0") to the end of the table (effect number would be Entries.Count after the add)
+    /// </summary>
+    public void AddEfa() => Entries.Add([0]);
+
+    /// <summary>
+    ///     Gets the next available effect id
+    /// </summary>
+    public int GetNextEffectId() => Entries.Count;
+
+    /// <summary>
+    ///     Inserts a frame order for the specified effect number
+    /// </summary>
+    /// <param name="effectNum">
+    ///     The effect number for which to insert (1-based)
+    /// </param>
+    /// <param name="frameOrder">
+    ///     The frame order for the effect
+    /// </param>
+    public void Insert(int effectNum, IEnumerable<int> frameOrder) => Entries.Insert(effectNum - 1, frameOrder.ToList());
+
+    /// <summary>
+    ///     Inserts an EFA frame order ("0") for the specified effect number
+    /// </summary>
+    public void InsertEfa() => Entries.Insert(0, [0]);
+
+    /// <summary>
+    ///     Clears the frame order for the specified effect id
+    /// </summary>
+    /// <param name="effectNum">
+    ///     The effect number to clear the frame order for. (1-indexed)
+    /// </param>
+    public void Remove(int effectNum) => Entries[effectNum - 1] = [];
+
+    #region SaveTo
+    /// <inheritdoc />
+    public void Save(string path)
+    {
+        using var stream = File.Open(
+            path.WithExtension(".tbl"),
+            new FileStreamOptions
+            {
+                Access = FileAccess.Write,
+                Mode = FileMode.Create,
+                Options = FileOptions.SequentialScan,
+                Share = FileShare.ReadWrite
+            });
+
+        Save(stream);
+    }
+
+    /// <inheritdoc />
+    public void Save(Stream stream)
+    {
+        using var writer = new StreamWriter(stream, Encoding.Default, leaveOpen: true);
+
+        writer.WriteLine(Entries.Count);
+
+        foreach (var entry in Entries)
+        {
+            var line = string.Join(' ', entry);
+            writer.WriteLine(line);
+        }
+    }
+    #endregion
+
+    #region LoadFrom
+    /// <summary>
+    ///     Loads an EffectTable from the specified archive
+    /// </summary>
+    /// <param name="rohDat">
+    ///     The DataArchive from which to retrieve the TBL file. (must be roh.dat)
+    /// </param>
+    public static EffectTable FromArchive(DataArchive rohDat)
+    {
+        if (!rohDat.TryGetValue("effect.tbl", out var entry))
+            throw new FileNotFoundException("TBL file with the name \"effect.tbl\" was not found in the archive");
+
+        return FromEntry(entry);
+    }
+
+    /// <summary>
+    ///     Loads an EffectTable from the specified entry
+    /// </summary>
+    /// <param name="entry">
+    ///     The DataArchiveEntry to load the EffectTable from.
+    /// </param>
+    public static EffectTable FromEntry(DataArchiveEntry entry)
+    {
+        using var segment = entry.ToStreamSegment();
+
+        return new EffectTable(segment);
+    }
+
+    /// <summary>
+    ///     Loads an EffectTable from the specified path
+    /// </summary>
+    /// <param name="path">
+    ///     The path to the file to be read
+    /// </param>
+    public static EffectTable FromFile(string path)
+    {
+        using var stream = File.Open(
+            path.WithExtension(".tbl"),
+            new FileStreamOptions
+            {
+                Access = FileAccess.Read,
+                Mode = FileMode.Open,
+                Options = FileOptions.SequentialScan,
+                Share = FileShare.ReadWrite
+            });
+
+        return new EffectTable(stream);
+    }
+    #endregion
+}

--- a/DALib/Drawing/EffectTableEntry.cs
+++ b/DALib/Drawing/EffectTableEntry.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace DALib.Drawing;
+
+/// <summary>
+///     Represents an entry in the effect table, containing a sequence of frame indexes that make up an animation.
+/// </summary>
+public sealed class EffectTableEntry : IEnumerable<int>
+{
+    /// <summary>
+    ///     A sequence of frame indexes that make up the animation.
+    /// </summary>
+    public List<int> FrameSequence { get; set; } = [];
+
+    /// <inheritdoc />
+    public IEnumerator<int> GetEnumerator() => FrameSequence.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    ///     Retrieves the frame index of the next frame in the sequuence
+    /// </summary>
+    /// <param name="currentAnimationIndex">
+    ///     The ID of the current tile
+    /// </param>
+    public int GetNextFrameIndex(int currentAnimationIndex)
+    {
+        if (currentAnimationIndex >= FrameSequence.Count)
+            currentAnimationIndex = 0;
+
+        return FrameSequence[currentAnimationIndex];
+    }
+}

--- a/DALib/Drawing/Graphics.cs
+++ b/DALib/Drawing/Graphics.cs
@@ -117,8 +117,9 @@ public static class Graphics
     {
         using var bitmap = new SKBitmap(efa.ImagePixelWidth, efa.ImagePixelHeight);
 
-        var pixelBuffer = new SKColor[bitmap.Width * bitmap.Height];
-        Array.Fill(pixelBuffer, CONSTANTS.Transparent);
+        using var pixMap = bitmap.PeekPixels();
+        var pixelBuffer = pixMap.GetPixelSpan<SKColor>();
+        pixelBuffer.Fill(CONSTANTS.Transparent);
 
         if (efa.ByteCount == 0)
             return SKImage.FromBitmap(bitmap);
@@ -163,15 +164,6 @@ public static class Graphics
 
                 pixelBuffer[yActual * bitmap.Width + xActual] = color;
             }
-
-        var handle = GCHandle.Alloc(pixelBuffer, GCHandleType.Pinned);
-
-        bitmap.InstallPixels(
-            bitmap.Info,
-            handle.AddrOfPinnedObject(),
-            bitmap.RowBytes,
-            Helpers.FreeHandle,
-            handle);
 
         return SKImage.FromBitmap(bitmap);
     }

--- a/DALib/Drawing/Graphics.cs
+++ b/DALib/Drawing/Graphics.cs
@@ -60,10 +60,13 @@ public static class Graphics
     /// <param name="palette">
     ///     A palette containing colors used by the frame
     /// </param>
-    public static SKImage RenderImage(HpfFile hpf, Palette palette)
+    /// <param name="yOffset">
+    ///     An optional custom offset used to move the image down, since these images are rendered from the bottom up
+    /// </param>
+    public static SKImage RenderImage(HpfFile hpf, Palette palette, int yOffset = 0)
         => SimpleRender(
             0,
-            0,
+            yOffset,
             hpf.PixelWidth,
             hpf.PixelHeight,
             hpf.Data,
@@ -385,8 +388,8 @@ public static class Graphics
     }
 
     private static SKImage SimpleRender(
-        int top,
         int left,
+        int top,
         int width,
         int height,
         byte[] data,

--- a/DALib/Drawing/Graphics.cs
+++ b/DALib/Drawing/Graphics.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 using System.Text;
 using DALib.Data;
 using DALib.Definitions;
@@ -348,9 +347,10 @@ public static class Graphics
         SKColor[] data)
     {
         using var bitmap = new SKBitmap(width + left, height + top);
+        using var pixMap = bitmap.PeekPixels();
 
-        var pixelBuffer = new SKColor[bitmap.Width * bitmap.Height];
-        Array.Fill(pixelBuffer, CONSTANTS.Transparent);
+        var pixelBuffer = pixMap.GetPixelSpan<SKColor>();
+        pixelBuffer.Fill(CONSTANTS.Transparent);
 
         for (var y = 0; y < height; y++)
             for (var x = 0; x < width; x++)
@@ -367,15 +367,6 @@ public static class Graphics
                 pixelBuffer[yActual * bitmap.Width + xActual] = color;
             }
 
-        var handle = GCHandle.Alloc(pixelBuffer, GCHandleType.Pinned);
-
-        bitmap.InstallPixels(
-            bitmap.Info,
-            handle.AddrOfPinnedObject(),
-            bitmap.RowBytes,
-            Helpers.FreeHandle,
-            handle);
-
         return SKImage.FromBitmap(bitmap);
     }
 
@@ -388,9 +379,10 @@ public static class Graphics
         Palette palette)
     {
         using var bitmap = new SKBitmap(width + left, height + top);
+        using var pixMap = bitmap.PeekPixels();
 
-        var pixelBuffer = new SKColor[bitmap.Width * bitmap.Height];
-        Array.Fill(pixelBuffer, CONSTANTS.Transparent);
+        var pixelBuffer = pixMap.GetPixelSpan<SKColor>();
+        pixelBuffer.Fill(CONSTANTS.Transparent);
 
         for (var y = 0; y < height; y++)
             for (var x = 0; x < width; x++)
@@ -406,15 +398,6 @@ public static class Graphics
 
                 pixelBuffer[yActual * bitmap.Width + xActual] = color;
             }
-
-        var handle = GCHandle.Alloc(pixelBuffer, GCHandleType.Pinned);
-
-        bitmap.InstallPixels(
-            bitmap.Info,
-            handle.AddrOfPinnedObject(),
-            bitmap.RowBytes,
-            Helpers.FreeHandle,
-            handle);
 
         return SKImage.FromBitmap(bitmap);
     }

--- a/DALib/Drawing/MpfFile.cs
+++ b/DALib/Drawing/MpfFile.cs
@@ -138,7 +138,7 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
     {
         HeaderType = headerType;
         FormatType = formatType;
-        UnknownHeaderBytes = HeaderType == MpfHeaderType.Unknown ? new byte[4] : Array.Empty<byte>();
+        UnknownHeaderBytes = HeaderType == MpfHeaderType.Unknown ? new byte[4] : [];
         PixelWidth = width;
         PixelHeight = height;
     }
@@ -173,7 +173,7 @@ public sealed class MpfFile : Collection<MpfFrame>, ISavable
             default:
                 stream.Seek(-4, SeekOrigin.Current);
 
-                UnknownHeaderBytes = Array.Empty<byte>();
+                UnknownHeaderBytes = [];
 
                 break;
         }

--- a/DALib/Drawing/TileAnimationEntry.cs
+++ b/DALib/Drawing/TileAnimationEntry.cs
@@ -21,7 +21,7 @@ public sealed class TileAnimationEntry : IEnumerable<ushort>
     /// <summary>
     ///     A sequence of tile IDs that make up the animation.
     /// </summary>
-    public List<ushort> TileSequence { get; set; } = new();
+    public List<ushort> TileSequence { get; set; } = [];
 
     /// <inheritdoc />
     public IEnumerator<ushort> GetEnumerator() => TileSequence.GetEnumerator();

--- a/DALib/Drawing/TileAnimationTable.cs
+++ b/DALib/Drawing/TileAnimationTable.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -11,7 +12,7 @@ namespace DALib.Drawing;
 /// <summary>
 ///     Represents a table of tile animations.
 /// </summary>
-public class TileAnimationTable : ISavable
+public sealed class TileAnimationTable : ISavable
 {
     private readonly Dictionary<int, TileAnimationEntry> Entries = new();
 
@@ -79,6 +80,17 @@ public class TileAnimationTable : ISavable
         foreach (var tileId in entry.TileSequence)
             Entries.Remove(tileId);
     }
+
+    /// <summary>
+    ///     Attempts to retrieve a TileAnimationEntry from the table
+    /// </summary>
+    /// <param name="tileId">
+    ///     The current tile id
+    /// </param>
+    /// <param name="entry">
+    ///     An entry containing a sequence of tiles
+    /// </param>
+    public bool TryGetEntry(int tileId, [MaybeNullWhen(false)] out TileAnimationEntry entry) => Entries.TryGetValue(tileId, out entry);
 
     #region SaveTo
     /// <inheritdoc />

--- a/DALib/Utility/MathEx.cs
+++ b/DALib/Utility/MathEx.cs
@@ -39,13 +39,27 @@ public static class MathEx
         T2 newMin,
         T2 newMax) where T1: INumber<T1>
                    where T2: INumber<T2>
-        => T2.CreateTruncating(
-            ScaleRange(
-                double.CreateTruncating(num),
-                double.CreateTruncating(min),
-                double.CreateTruncating(max),
-                double.CreateTruncating(newMin),
-                double.CreateTruncating(newMax)));
+    {
+        var ret = ScaleRange(
+            double.CreateTruncating(num),
+            double.CreateTruncating(min),
+            double.CreateTruncating(max),
+            double.CreateTruncating(newMin),
+            double.CreateTruncating(newMax));
+
+        //get a rounded value and a truncated value
+        var roundedValue = Math.Round(ret, MidpointRounding.AwayFromZero);
+        var truncatedValue = T2.CreateTruncating(ret);
+
+        //take whichever value is closer to the true value
+        var roundedDiff = Math.Abs(roundedValue - ret);
+        var truncatedDiff = Math.Abs(double.CreateTruncating(truncatedValue) - ret);
+
+        if (roundedDiff < truncatedDiff)
+            return T2.CreateTruncating(roundedValue);
+
+        return truncatedValue;
+    }
 
     /// <summary>
     ///     Scales a number from one range to another range.


### PR DESCRIPTION
- added EffectTable and EffectTable entry, to represent effect.tbl in roh.dat
- added PatchEntry to allow patching an archive without knowing the underlying type
- added a way to fetch TileAnimationEntries from TileAnimationTable
- fixed a rounding error when scaling colors (this caused a slight green tint to some spf images)
- fixed a bug with DataArchive saving where order of existing entries was not preserved
- fixed a bug with DataArchive patching, where if you patch over an existing file, it's index in the archive was not preserved
- improved rendering performance by skipping a large array creation
- added DataArchive.Compile which takes a directory and spits out an archive without having to load the archive into memory