### PR TITLE
misc bugs

### DIFF
--- a/DALib/Data/MetaFile.cs
+++ b/DALib/Data/MetaFile.cs
@@ -69,7 +69,7 @@ public sealed class MetaFile : Collection<MetaFileEntry>, ISavable
         if (!isCompressed)
             return new MetaFile(stream);
 
-        using var decompressor = new DeflateStream(stream, CompressionMode.Decompress);
+        using var decompressor = new ZLibStream(stream, CompressionMode.Decompress);
 
         return new MetaFile(decompressor);
     }
@@ -80,7 +80,7 @@ public sealed class MetaFile : Collection<MetaFileEntry>, ISavable
     public void Save(string path)
     {
         using var stream = File.Open(
-            path.WithExtension(".meta"),
+            path,
             new FileStreamOptions
             {
                 Access = FileAccess.Write,
@@ -88,8 +88,9 @@ public sealed class MetaFile : Collection<MetaFileEntry>, ISavable
                 Options = FileOptions.SequentialScan,
                 Share = FileShare.ReadWrite
             });
+        using var compressor = new ZLibStream(stream, CompressionMode.Compress);
 
-        Save(stream);
+        Save(compressor);
     }
 
     /// <inheritdoc />

--- a/DALib/Extensions/SKImageExtensions.cs
+++ b/DALib/Extensions/SKImageExtensions.cs
@@ -25,16 +25,16 @@ public static class SKImageExtensions
                               .DistinctBy(set => set.c)
                               .ToDictionary(set => set.c, c => (byte)c.i);
         var pixelData = new byte[image.Width * image.Height];
+        using var pixels = image.PeekPixels();
 
         for (var y = 0; y < image.Height; ++y)
         {
             for (var x = 0; x < image.Width; ++x)
             {
                 var pixelIndex = y * image.Width + x;
-                using var pixels = image.PeekPixels();
 
-                var color = pixels.GetPixelColor(x, y)
-                                  .WithAlpha(byte.MaxValue);
+                var trueColor = pixels.GetPixelColor(x, y);
+                var color = trueColor.WithAlpha(byte.MaxValue);
 
                 if (!colorMap.TryGetValue(color, out var colorIndex))
                     throw new InvalidOperationException("Color not found in palette.");

--- a/DALib/Utility/ImageProcessor.cs
+++ b/DALib/Utility/ImageProcessor.cs
@@ -52,11 +52,17 @@ public static class ImageProcessor
     /// <param name="image">
     ///     The image whose black pixels to preserve
     /// </param>
-    public static void PreserveNonTransparentBlacks(SKImage image)
+    public static SKImage PreserveNonTransparentBlacks(SKImage image)
     {
         using var bitmap = SKBitmap.FromImage(image);
 
         PreserveNonTransparentBlacks(bitmap);
+
+        var ret = SKImage.FromBitmap(bitmap);
+
+        image.Dispose();
+
+        return ret;
     }
 
     /// <summary>
@@ -85,10 +91,10 @@ public static class ImageProcessor
     /// <param name="images">
     ///     The images whose black pixels to preserve
     /// </param>
-    public static void PreserveNonTransparentBlacks(IEnumerable<SKImage> images)
+    public static void PreserveNonTransparentBlacks(IList<SKImage> images)
     {
-        foreach (var image in images)
-            PreserveNonTransparentBlacks(image);
+        for (var i = 0; i < images.Count; i++)
+            images[i] = PreserveNonTransparentBlacks(images[i]);
     }
 
     /// <summary>

--- a/DALib/Utility/ImageProcessor.cs
+++ b/DALib/Utility/ImageProcessor.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using DALib.Definitions;
 using DALib.Extensions;
 using KGySoft.Drawing.Imaging;
 using KGySoft.Drawing.SkiaSharp;
 using SkiaSharp;
+using Palette = DALib.Drawing.Palette;
 
 namespace DALib.Utility;
 
@@ -116,11 +116,14 @@ public static class ImageProcessor
         var colorCount = existingPixels.Distinct()
                                        .Count();
 
-        var pixelBuffer = new SKColor[quantizedBitmap.Width * quantizedBitmap.Height];
+        using var quantizedPixMap = quantizedBitmap.PeekPixels();
 
-        //dont quantize/dither if the image already has less than maximum number of colors
+        var pixelBuffer = quantizedPixMap.GetPixelSpan<SKColor>();
+        pixelBuffer.Fill(CONSTANTS.Transparent);
+
+        //don't quantize/dither if the image already has less than maximum number of colors
         if (colorCount <= options.MaxColors)
-            existingPixels.CopyTo(pixelBuffer.AsSpan());
+            existingPixels.CopyTo(pixelBuffer);
         else if (options.Ditherer is not null)
         {
             using var dSession = options.Ditherer!.Initialize(source, qSession);
@@ -149,21 +152,30 @@ public static class ImageProcessor
                 }
             }
 
-        var handle = GCHandle.Alloc(pixelBuffer, GCHandleType.Pinned);
-
-        quantizedBitmap.InstallPixels(
-            quantizedBitmap.Info,
-            handle.AddrOfPinnedObject(),
-            quantizedBitmap.RowBytes,
-            Helpers.FreeHandle,
-            handle);
-
         var quantizedImage = SKImage.FromBitmap(quantizedBitmap);
+        Palette? palette;
+
+        if (colorCount <= options.MaxColors)
+            palette = new Palette(
+                existingPixels.Select(
+                                  c =>
+                                  {
+                                      //normally the quantizer would set all fully transparent pixels to black
+                                      //but since we didn't quantize the image, we have to do it manually
+                                      if (c.Alpha == 0)
+                                          return SKColors.Black;
+
+                                      return c;
+                                  })
+                              .Distinct()
+                              .OrderBy(c => c.GetLuminance()));
+        else
+            palette = qSession.Palette!.ToDALibPalette();
 
         return new Palettized<SKImage>
         {
             Entity = quantizedImage,
-            Palette = qSession.Palette!.ToDALibPalette()
+            Palette = palette
         };
     }
 
@@ -184,7 +196,7 @@ public static class ImageProcessor
     {
         const int PADDING = 1;
 
-        //create a mosaic of all of the individual images
+        //create a mosaic of all the individual images
         using var mosaic = CreateMosaic(PADDING, images);
         using var quantizedMosaic = Quantize(options, mosaic);
         using var bitmap = SKBitmap.FromImage(quantizedMosaic.Entity);

--- a/DALib/Utility/SKImageCollection.cs
+++ b/DALib/Utility/SKImageCollection.cs
@@ -3,13 +3,17 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using SkiaSharp;
+// ReSharper disable ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
 
 namespace DALib.Utility;
 
 /// <summary>
 ///     Represents a disposable collection of SKImages.
 /// </summary>
-public class SKImageCollection(IEnumerable<SKImage> images) : Collection<SKImage>(images.ToList()), IDisposable
+public class SKImageCollection(IEnumerable<SKImage> images) : Collection<SKImage>(
+                                                                  images.Where(frame => frame is not null)
+                                                                        .ToList()),
+                                                              IDisposable
 {
     /// <inheritdoc />
     public virtual void Dispose()


### PR DESCRIPTION
- metafiles do not end in ".meta"
- metafiles use Zlib compression, not generic Deflate
- fixed multiple bugs around non-transparent black preservation, particularly when the image is being quantized
- removed unsafe gchandle pinning, turns out it wasnt needed