### PR TITLE
Map rendering fix

### DIFF
--- a/DALib/DALib.csproj
+++ b/DALib/DALib.csproj
@@ -3,12 +3,12 @@
         <!--suppress MsbuildTargetFrameworkTagInspection -->
         <TargetFrameworks>net8.0</TargetFrameworks>
         <PackageId>DALib</PackageId>
-        <PackageVersion>0.5.1</PackageVersion>
+        <PackageVersion>0.5.2</PackageVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIcon>hybrasyl-512x512.png</PackageIcon>
         <ProjectUrl>https://github.com/eriscorp/dalib</ProjectUrl>
-        <Version>0.5.1</Version>
+        <Version>0.5.2</Version>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Authors>Kyle Speck and contributors</Authors>

--- a/DALib/DALib.csproj
+++ b/DALib/DALib.csproj
@@ -3,12 +3,12 @@
         <!--suppress MsbuildTargetFrameworkTagInspection -->
         <TargetFrameworks>net8.0</TargetFrameworks>
         <PackageId>DALib</PackageId>
-        <PackageVersion>0.3.0</PackageVersion>
+        <PackageVersion>0.5.1</PackageVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIcon>hybrasyl-512x512.png</PackageIcon>
         <ProjectUrl>https://github.com/eriscorp/dalib</ProjectUrl>
-        <Version>0.3.0</Version>
+        <Version>0.5.1</Version>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Authors>Kyle Speck and contributors</Authors>

--- a/DALib/DALib.csproj
+++ b/DALib/DALib.csproj
@@ -3,15 +3,15 @@
         <!--suppress MsbuildTargetFrameworkTagInspection -->
         <TargetFrameworks>net8.0</TargetFrameworks>
         <PackageId>DALib</PackageId>
-        <PackageVersion>0.1.0</PackageVersion>
+        <PackageVersion>0.3.0</PackageVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIcon>hybrasyl-512x512.png</PackageIcon>
         <ProjectUrl>https://github.com/eriscorp/dalib</ProjectUrl>
-        <Version>0.1.0</Version>
+        <Version>0.3.0</Version>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <Authors>See CONTRIBUTORS.md</Authors>
+        <Authors>Kyle Speck and contributors</Authors>
         <Copyright>See CONTRIBUTORS.md</Copyright>
         <RepositoryUrl>https://github.com/eriscorp/dalib</RepositoryUrl>
         <Tags>hybrasyl; dalib; epf; spf; hpf; doomvas;</Tags>

--- a/DALib/Data/MapFile.cs
+++ b/DALib/Data/MapFile.cs
@@ -1,8 +1,8 @@
-﻿using System.IO;
-using System.Text;
-using DALib.Abstractions;
+﻿using DALib.Abstractions;
 using DALib.Drawing;
 using DALib.Extensions;
+using System.IO;
+using System.Text;
 
 namespace DALib.Data;
 
@@ -29,6 +29,9 @@ public sealed class MapFile(int width, int height) : ISavable
     private MapFile(Stream stream, int width, int height)
         : this(width, height)
     {
+        if (stream.Length != width * height * 6)
+            throw new InvalidDataException("Invalid map file");
+
         using var reader = new BinaryReader(stream, Encoding.Default, true);
 
         for (var y = 0; y < Height; ++y)

--- a/DALib/Drawing/Tileset.cs
+++ b/DALib/Drawing/Tileset.cs
@@ -1,14 +1,14 @@
-﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq;
-using System.Text;
-using DALib.Abstractions;
+﻿using DALib.Abstractions;
 using DALib.Data;
 using DALib.Definitions;
 using DALib.Extensions;
 using DALib.Utility;
 using SkiaSharp;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
 
 namespace DALib.Drawing;
 

--- a/DALib/Utility/MapImageCache.cs
+++ b/DALib/Utility/MapImageCache.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace DALib.Utility;
+
+/// <summary>
+/// A collection of <see cref="SKImageCache{TKey}"/> caches that can be used as a shared cache for rendering multiple maps.
+/// </summary>
+/// <param name="bgCache">The background cache</param>
+/// <param name="lfgCache">The left foreground cache</param>
+/// <param name="rfgCache">The right foreground cache</param>
+public class MapImageCache(SKImageCache<int> bgCache, SKImageCache<int> lfgCache, SKImageCache<int> rfgCache): IDisposable
+{
+    /// <summary>
+    /// The background cache
+    /// </summary>
+    public SKImageCache<int> BackgroundCache { get; } = bgCache;
+    /// <summary>
+    /// The left foreground cache
+    /// </summary>
+    public SKImageCache<int> LeftForegroundCache { get; } = lfgCache;
+    /// <summary>
+    /// The right foreground cache
+    /// </summary>
+    public SKImageCache<int> RightForegroundCache { get; } = rfgCache;
+
+    /// <inheritdoc/>
+    public virtual void Dispose()
+    {
+        BackgroundCache.Dispose();
+        LeftForegroundCache.Dispose();
+        RightForegroundCache.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}
+

--- a/DALib/Utility/MapImageCache.cs
+++ b/DALib/Utility/MapImageCache.cs
@@ -5,23 +5,41 @@ namespace DALib.Utility;
 /// <summary>
 /// A collection of <see cref="SKImageCache{TKey}"/> caches that can be used as a shared cache for rendering multiple maps.
 /// </summary>
-/// <param name="bgCache">The background cache</param>
-/// <param name="lfgCache">The left foreground cache</param>
-/// <param name="rfgCache">The right foreground cache</param>
-public class MapImageCache(SKImageCache<int> bgCache, SKImageCache<int> lfgCache, SKImageCache<int> rfgCache): IDisposable
+public class MapImageCache: IDisposable
 {
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MapImageCache"/> class.
+    /// </summary>
+    public MapImageCache()
+    {
+        BackgroundCache = new SKImageCache<int>();
+        LeftForegroundCache = new SKImageCache<int>();
+        RightForegroundCache = new SKImageCache<int>();
+    }
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MapImageCache"/> class using the specified caches.
+    /// </summary>
+    /// <param name="bgCache">The background cache</param>
+    /// <param name="lfgCache">The left foreground cache</param>
+    /// <param name="rfgCache">The right foreground cache</param>
+    public MapImageCache(SKImageCache<int> bgCache, SKImageCache<int> lfgCache, SKImageCache<int> rfgCache)
+    {
+        BackgroundCache = bgCache;
+        LeftForegroundCache = lfgCache;
+        RightForegroundCache = rfgCache;
+    }
     /// <summary>
     /// The background cache
     /// </summary>
-    public SKImageCache<int> BackgroundCache { get; } = bgCache;
+    public SKImageCache<int> BackgroundCache { get; }
     /// <summary>
     /// The left foreground cache
     /// </summary>
-    public SKImageCache<int> LeftForegroundCache { get; } = lfgCache;
+    public SKImageCache<int> LeftForegroundCache { get; }
     /// <summary>
     /// The right foreground cache
     /// </summary>
-    public SKImageCache<int> RightForegroundCache { get; } = rfgCache;
+    public SKImageCache<int> RightForegroundCache { get; }
 
     /// <inheritdoc/>
     public virtual void Dispose()

--- a/DALib/Utility/SKImageCache.cs
+++ b/DALib/Utility/SKImageCache.cs
@@ -1,6 +1,6 @@
+using SkiaSharp;
 using System;
 using System.Collections.Generic;
-using SkiaSharp;
 
 namespace DALib.Utility;
 


### PR DESCRIPTION
Fixes rendering error for non-isometric maps. Also adds `MapImageCache` as a parameter to `RenderMap` to allow a shared cache to be used (I intend to use it for rendering multiple maps at a time, because doing the individual tile renderings over and over is suboptimal). I also made the padding configurable.
