### PR TITLE
foscail: DAT unpack/convert tool + DataArchive hardening + empty-frame render fix

### DIFF
--- a/DALib.Tests/DALib.Tests.csproj
+++ b/DALib.Tests/DALib.Tests.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <!-- Native Skia so rendering tests run on Linux; base SkiaSharp bundles only Windows/macOS natives. Test-only, not shipped. -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DALib.Tests/DataArchiveTests.cs
+++ b/DALib.Tests/DataArchiveTests.cs
@@ -1,0 +1,154 @@
+using System.Text;
+using DALib.Data;
+
+namespace DALib.Tests;
+
+/// <summary>
+///     Covers the DataArchive hardening around hostile or non-legacy input: entry names that would
+///     escape the extraction directory, the extended-format (leading 0xFFFFFFFF) layout that the
+///     legacy parser would otherwise read as an empty archive, and path handling for files whose
+///     extension casing differs from ".dat".
+/// </summary>
+public class DataArchiveTests
+{
+    // legacy index layout: [count+1:i32] then per entry [start:i32][name:13 ascii, NUL padded],
+    // a final [end:i32], then the concatenated entry data
+    private static byte[] BuildArchive(params (string Name, byte[] Data)[] entries)
+    {
+        const int NAME_LENGTH = 13;
+
+        using var ms = new MemoryStream();
+
+        using (var writer = new BinaryWriter(ms, Encoding.Default, true))
+        {
+            writer.Write(entries.Length + 1);
+
+            var address = 4 + entries.Length * (4 + NAME_LENGTH) + 4;
+
+            foreach (var (name, data) in entries)
+            {
+                writer.Write(address);
+                writer.Write(Encoding.ASCII.GetBytes(name.PadRight(NAME_LENGTH, '\0')));
+
+                address += data.Length;
+            }
+
+            writer.Write(address);
+
+            foreach (var (_, data) in entries)
+                writer.Write(data);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static string WriteTempFile(byte[] bytes, string extension)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"dalib-archive-{Guid.NewGuid():N}{extension}");
+        File.WriteAllBytes(path, bytes);
+
+        return path;
+    }
+
+    [Fact]
+    public void ExtractTo_Extracts_Normal_Entries()
+    {
+        var payload = "hello"u8.ToArray();
+        var path = WriteTempFile(BuildArchive(("a.txt", payload)), ".dat");
+        var destDir = Directory.CreateTempSubdirectory("dalib-extract-").FullName;
+
+        try
+        {
+            using var archive = DataArchive.FromFile(path);
+
+            archive.Count.Should().Be(1);
+            archive.ExtractTo(destDir);
+
+            File.ReadAllBytes(Path.Combine(destDir, "a.txt")).Should().BeEquivalentTo(payload);
+        } finally
+        {
+            File.Delete(path);
+            Directory.Delete(destDir, true);
+        }
+    }
+
+    [Theory]
+    [InlineData("../evil")]
+    [InlineData("/tmp/evil")]
+    public void ExtractTo_Rejects_EntryNames_That_Escape_The_Destination(string entryName)
+    {
+        var path = WriteTempFile(BuildArchive((entryName, [1, 2, 3])), ".dat");
+
+        // nested destination so a "../" escape would land in scratchDir, where we can check for it
+        var scratchDir = Directory.CreateTempSubdirectory("dalib-escape-").FullName;
+        var destDir = Path.Combine(scratchDir, "out");
+        Directory.CreateDirectory(destDir);
+
+        try
+        {
+            using var archive = DataArchive.FromFile(path);
+
+            var extract = () => archive.ExtractTo(destDir);
+
+            extract.Should().Throw<InvalidDataException>();
+            File.Exists(Path.Combine(scratchDir, "evil")).Should().BeFalse();
+        } finally
+        {
+            File.Delete(path);
+            Directory.Delete(scratchDir, true);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FromFile_Throws_On_Negative_Entry_Count(bool memoryMapped)
+    {
+        // the extended-format layout leads with 0xFFFFFFFF; the legacy parser must reject it
+        // instead of reading it as a count and yielding an empty archive
+        var path = WriteTempFile([0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00], ".dat");
+
+        try
+        {
+            var open = () => DataArchive.FromFile(path, memoryMapped);
+
+            open.Should().Throw<InvalidDataException>();
+        } finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void FromFile_Honors_Path_With_Uppercase_Extension()
+    {
+        // FromFile used to rewrite "X.DAT" to "X.dat", which does not exist on case-sensitive filesystems
+        var path = WriteTempFile(BuildArchive(("a.txt", [1])), ".DAT");
+
+        try
+        {
+            using var archive = DataArchive.FromFile(path);
+
+            archive.Count.Should().Be(1);
+        } finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void FromFile_Still_Appends_Extension_To_Extensionless_Path()
+    {
+        var path = WriteTempFile(BuildArchive(("a.txt", [1])), ".dat");
+
+        try
+        {
+            using var archive = DataArchive.FromFile(path[..^4]);
+
+            archive.Count.Should().Be(1);
+        } finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/DALib.Tests/GraphicsEmptyFrameTests.cs
+++ b/DALib.Tests/GraphicsEmptyFrameTests.cs
@@ -1,0 +1,51 @@
+using DALib.Drawing;
+using FluentAssertions;
+
+namespace DALib.Tests;
+
+/// <summary>
+///     Regression coverage for the empty-frame guard in <see cref="Graphics" />'s shared
+///     <c>SimpleRender</c> helper. SPF (and MPF/HPF/Tile) frames can be empty placeholders encoded with
+///     non-positive — often negative — dimensions (<c>Right &lt; Left</c> ⇒ <c>PixelWidth &lt; 0</c>) and
+///     no pixel data. Before the guard, rendering such a frame built <c>new SKBitmap(&lt;=0, …)</c>, whose
+///     <c>PeekPixels()</c> is null, and threw a NullReferenceException — hit the moment any caller iterated
+///     every frame of a real SPF (e.g. the setoa.dat UI sprites). The EPF/EFA overloads already guarded
+///     this; the fix moved the guard into SimpleRender so every caller is covered.
+/// </summary>
+public class GraphicsEmptyFrameTests
+{
+    // Right < Left and Bottom < Top => negative PixelWidth/PixelHeight: the empty-frame encoding.
+    private static SpfFrame EmptyFrame() => new()
+    {
+        Left = 45,
+        Right = 0,
+        Top = 16,
+        Bottom = 0
+    };
+
+    [Fact]
+    public void RenderImage_PalettizedSpfFrame_WithEmptyFrame_ReturnsPlaceholderInsteadOfThrowing()
+    {
+        var frame = EmptyFrame();
+        frame.Data = [];
+
+        var render = () => Graphics.RenderImage(frame, new Palette());
+
+        using var image = render.Should().NotThrow().Subject;
+        image.Width.Should().Be(1);
+        image.Height.Should().Be(1);
+    }
+
+    [Fact]
+    public void RenderImage_ColorizedSpfFrame_WithEmptyFrame_ReturnsPlaceholderInsteadOfThrowing()
+    {
+        var frame = EmptyFrame();
+        frame.ColorData = [];
+
+        var render = () => Graphics.RenderImage(frame);
+
+        using var image = render.Should().NotThrow().Subject;
+        image.Width.Should().Be(1);
+        image.Height.Should().Be(1);
+    }
+}

--- a/DALib.sln
+++ b/DALib.sln
@@ -1,11 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.35919.96 d17.13
+VisualStudioVersion = 17.13.35919.96
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DALib", "DALib\DALib.csproj", "{57DC0659-CA9A-47E0-BE98-4949C9021400}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DALib.Tests", "DALib.Tests\DALib.Tests.csproj", "{EBECF1F2-2DE4-46B5-A962-49DEAF7C5DEA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Foscail", "Foscail\Foscail.csproj", "{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Foscail.Tests", "Foscail.Tests\Foscail.Tests.csproj", "{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,6 +45,30 @@ Global
 		{EBECF1F2-2DE4-46B5-A962-49DEAF7C5DEA}.Release|x64.Build.0 = Release|Any CPU
 		{EBECF1F2-2DE4-46B5-A962-49DEAF7C5DEA}.Release|x86.ActiveCfg = Release|Any CPU
 		{EBECF1F2-2DE4-46B5-A962-49DEAF7C5DEA}.Release|x86.Build.0 = Release|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Debug|x64.Build.0 = Debug|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Debug|x86.Build.0 = Debug|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Release|x64.ActiveCfg = Release|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Release|x64.Build.0 = Release|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Release|x86.ActiveCfg = Release|Any CPU
+		{60FB4C23-CC1B-4093-BE38-4D2E76743AE8}.Release|x86.Build.0 = Release|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Debug|x64.Build.0 = Debug|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Debug|x86.Build.0 = Debug|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Release|x64.ActiveCfg = Release|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Release|x64.Build.0 = Release|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Release|x86.ActiveCfg = Release|Any CPU
+		{8D627D3C-AE19-4D77-9F18-8C9BB023C2B8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DALib/Data/DataArchive.cs
+++ b/DALib/Data/DataArchive.cs
@@ -40,7 +40,14 @@ public class DataArchive : KeyedCollection<string, DataArchiveEntry>, ISavable, 
 
         using var reader = new BinaryReader(BaseStream, Encoding.Default, true);
 
-        var expectedNumberOfEntries = reader.ReadInt32() - 1;
+        var entryCountWord = reader.ReadInt32();
+
+        // A negative count word means this is not a legacy-index archive (the extended/compressed
+        // layout leads with 0xFFFFFFFF); parsing on would silently yield an empty archive.
+        if (entryCountWord < 0)
+            throw new InvalidDataException($"Not a supported DAT archive (entry count word is {entryCountWord})");
+
+        var expectedNumberOfEntries = entryCountWord - 1;
 
         for (var i = 0; i < expectedNumberOfEntries; ++i)
         {
@@ -172,9 +179,18 @@ public class DataArchive : KeyedCollection<string, DataArchiveEntry>, ISavable, 
     {
         ThrowIfDisposed();
 
+        var destRoot = Path.GetFullPath(dir);
+
+        if (!Path.EndsInDirectorySeparator(destRoot))
+            destRoot += Path.DirectorySeparatorChar;
+
         foreach (var entry in this)
         {
-            var path = Path.Combine(dir, entry.EntryName);
+            // entry names come from archive bytes; refuse any that would resolve outside the destination
+            var path = Path.GetFullPath(entry.EntryName, destRoot);
+
+            if (!path.StartsWith(destRoot, StringComparison.Ordinal))
+                throw new InvalidDataException($"Entry name \"{entry.EntryName}\" resolves outside the destination directory");
 
             using var stream = File.Create(path);
             using var segment = GetEntryStream(entry);
@@ -635,11 +651,15 @@ public class DataArchive : KeyedCollection<string, DataArchiveEntry>, ISavable, 
     /// </returns>
     public static DataArchive FromFile(string path, bool memoryMapped = true, bool newformat = false)
     {
+        // honor the caller's path when the file exists as-given; WithExtension is only the
+        // "name without extension" convenience (it would rewrite e.g. "FOO.DAT" to "FOO.dat")
+        var resolvedPath = File.Exists(path) ? path : path.WithExtension(".dat");
+
         if (memoryMapped)
         {
             //use a memory mapped file
             var fs = File.Open(
-                path.WithExtension(".dat"),
+                resolvedPath,
                 new FileStreamOptions
                 {
                     Access = FileAccess.Read,
@@ -662,7 +682,7 @@ public class DataArchive : KeyedCollection<string, DataArchiveEntry>, ISavable, 
 
         //load the file into memory
         using var fileStream = File.Open(
-            path.WithExtension(".dat"),
+            resolvedPath,
             new FileStreamOptions
             {
                 Access = FileAccess.Read,

--- a/DALib/Drawing/Graphics.cs
+++ b/DALib/Drawing/Graphics.cs
@@ -1096,6 +1096,16 @@ public static class Graphics
         int height,
         SKColor[] data)
     {
+        //empty/degenerate frame (non-positive dimensions): return a 1x1 transparent image so callers
+        //that iterate every frame don't crash on SKBitmap(<=0, ...). Matches the EpfFrame/EfaFrame guards.
+        if ((width <= 0) || (height <= 0))
+        {
+            using var emptyBitmap = new SKBitmap(1, 1, SKColorType.Bgra8888, SKAlphaType.Premul);
+            emptyBitmap.Erase(CONSTANTS.Transparent);
+
+            return SKImage.FromBitmap(emptyBitmap);
+        }
+
         //when left/top are negative, skip the padding and shift pixels to 0
         var dstOffsetX = Math.Max(0, left);
         var dstOffsetY = Math.Max(0, top);
@@ -1135,6 +1145,16 @@ public static class Graphics
         Palette palette,
         SKAlphaType alphaType = SKAlphaType.Premul)
     {
+        //empty/degenerate frame (non-positive dimensions): return a 1x1 transparent image so callers
+        //that iterate every frame don't crash on SKBitmap(<=0, ...). Matches the EpfFrame/EfaFrame guards.
+        if ((width <= 0) || (height <= 0))
+        {
+            using var emptyBitmap = new SKBitmap(1, 1, SKColorType.Bgra8888, alphaType);
+            emptyBitmap.Erase(CONSTANTS.Transparent);
+
+            return SKImage.FromBitmap(emptyBitmap);
+        }
+
         //when left/top are negative, skip the padding and shift pixels to 0
         var dstOffsetX = Math.Max(0, left);
         var dstOffsetY = Math.Max(0, top);

--- a/Foscail.Tests/Foscail.Tests.csproj
+++ b/Foscail.Tests/Foscail.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>14</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <!-- Native Skia so the convert path can run on Linux; base SkiaSharp bundles only Windows/macOS natives. -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Foscail\Foscail.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="FluentAssertions" />
+  </ItemGroup>
+
+</Project>

--- a/Foscail.Tests/UnpackCommandTests.cs
+++ b/Foscail.Tests/UnpackCommandTests.cs
@@ -1,0 +1,133 @@
+using System.Text;
+using Foscail.Commands;
+
+namespace Foscail.Tests;
+
+/// <summary>
+///     End-to-end coverage of <c>foscail unpack</c> via <see cref="UnpackCommand.Run" />: the happy
+///     path over a synthetic archive, batch continuation when one archive is hostile or unreadable,
+///     explicit reporting of extended-format archives, and case-insensitive .dat discovery.
+/// </summary>
+public class UnpackCommandTests : IDisposable
+{
+    private readonly string OutputDir;
+    private readonly string ScratchDir;
+
+    public UnpackCommandTests()
+    {
+        ScratchDir = Directory.CreateTempSubdirectory("foscail-tests-").FullName;
+        OutputDir = Path.Combine(ScratchDir, "out");
+    }
+
+    public void Dispose() => Directory.Delete(ScratchDir, true);
+
+    // legacy index layout: [count+1:i32] then per entry [start:i32][name:13 ascii, NUL padded],
+    // a final [end:i32], then the concatenated entry data
+    private static byte[] BuildArchive(params (string Name, byte[] Data)[] entries)
+    {
+        const int NAME_LENGTH = 13;
+
+        using var ms = new MemoryStream();
+
+        using (var writer = new BinaryWriter(ms, Encoding.Default, true))
+        {
+            writer.Write(entries.Length + 1);
+
+            var address = 4 + entries.Length * (4 + NAME_LENGTH) + 4;
+
+            foreach (var (name, data) in entries)
+            {
+                writer.Write(address);
+                writer.Write(Encoding.ASCII.GetBytes(name.PadRight(NAME_LENGTH, '\0')));
+
+                address += data.Length;
+            }
+
+            writer.Write(address);
+
+            foreach (var (_, data) in entries)
+                writer.Write(data);
+        }
+
+        return ms.ToArray();
+    }
+
+    private string WriteArchive(string fileName, byte[] bytes)
+    {
+        var path = Path.Combine(ScratchDir, fileName);
+        File.WriteAllBytes(path, bytes);
+
+        return path;
+    }
+
+    [Fact]
+    public void Run_Unpacks_A_Single_Archive()
+    {
+        var payload = "hello"u8.ToArray();
+        var path = WriteArchive("simple.dat", BuildArchive(("a.txt", payload)));
+
+        var exitCode = UnpackCommand.Run(path, OutputDir, convert: false);
+
+        exitCode.Should().Be(0);
+        File.ReadAllBytes(Path.Combine(OutputDir, "simple", "a.txt")).Should().BeEquivalentTo(payload);
+    }
+
+    [Fact]
+    public void Run_Continues_The_Batch_When_One_Archive_Is_Hostile()
+    {
+        var archiveDir = Path.Combine(ScratchDir, "archives");
+        Directory.CreateDirectory(archiveDir);
+
+        // hostile: a traversal entry name; sorts before "good.dat" so failure must not end the batch
+        File.WriteAllBytes(Path.Combine(archiveDir, "bad.dat"), BuildArchive(("../evil", [1, 2, 3])));
+        File.WriteAllBytes(Path.Combine(archiveDir, "good.dat"), BuildArchive(("a.txt", [4, 5])));
+
+        var exitCode = UnpackCommand.Run(archiveDir, OutputDir, convert: false);
+
+        exitCode.Should().Be(2);
+        File.Exists(Path.Combine(OutputDir, "good", "a.txt")).Should().BeTrue();
+        File.Exists(Path.Combine(OutputDir, "evil")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Run_Reports_ExtendedFormat_Archives_And_Continues()
+    {
+        var archiveDir = Path.Combine(ScratchDir, "archives");
+        Directory.CreateDirectory(archiveDir);
+
+        File.WriteAllBytes(Path.Combine(archiveDir, "extended.dat"), [0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00]);
+        File.WriteAllBytes(Path.Combine(archiveDir, "good.dat"), BuildArchive(("a.txt", [4, 5])));
+
+        var exitCode = UnpackCommand.Run(archiveDir, OutputDir, convert: false);
+
+        // extended archive counts as a failure (never a silent zero-entry success); the batch continues
+        exitCode.Should().Be(2);
+        File.Exists(Path.Combine(OutputDir, "good", "a.txt")).Should().BeTrue();
+        Directory.Exists(Path.Combine(OutputDir, "extended")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Run_Finds_Archives_With_Uppercase_Extension()
+    {
+        var archiveDir = Path.Combine(ScratchDir, "archives");
+        Directory.CreateDirectory(archiveDir);
+
+        File.WriteAllBytes(Path.Combine(archiveDir, "UPPER.DAT"), BuildArchive(("a.txt", [7])));
+
+        var exitCode = UnpackCommand.Run(archiveDir, OutputDir, convert: false);
+
+        exitCode.Should().Be(0);
+        File.Exists(Path.Combine(OutputDir, "UPPER", "a.txt")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Run_Unpacks_An_Uppercase_Archive_Passed_Directly()
+    {
+        var path = WriteArchive("DIRECT.DAT", BuildArchive(("a.txt", [8])));
+
+        var exitCode = UnpackCommand.Run(path, OutputDir, convert: false);
+
+        exitCode.Should().Be(0);
+        File.Exists(Path.Combine(OutputDir, "DIRECT", "a.txt")).Should().BeTrue();
+    }
+}

--- a/Foscail/Commands/UnpackCommand.cs
+++ b/Foscail/Commands/UnpackCommand.cs
@@ -1,0 +1,180 @@
+using System.Buffers.Binary;
+using System.CommandLine;
+using DALib.Data;
+using Foscail.Conversion;
+
+namespace Foscail.Commands;
+
+/// <summary>
+///     `foscail unpack` — extract every entry from one or more DAT archives into individual files,
+///     optionally converting self-contained image assets to PNG.
+/// </summary>
+internal static class UnpackCommand
+{
+    // sotp.dat and friends share the .dat extension but are not asset archives; opening them as one misparses.
+    private static readonly HashSet<string> NonArchiveNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "sotp.dat"
+    };
+
+    public static Command Build()
+    {
+        var inputArg = new Argument<string>("input")
+        {
+            Description = "A .dat archive, or a directory containing .dat archives."
+        };
+
+        var outputOpt = new Option<string?>("--output", "-o")
+        {
+            Description = "Output directory. Each archive is unpacked into its own subdirectory here. Defaults to ./foscail-out."
+        };
+
+        var convertOpt = new Option<bool>("--convert", "-c")
+        {
+            Description = "Also convert self-contained image assets (SPF, EFA) to PNG alongside the raw files."
+        };
+
+        var command = new Command("unpack",
+            "Extract every entry from one or more DAT archives into individual files.");
+        command.Add(inputArg);
+        command.Add(outputOpt);
+        command.Add(convertOpt);
+
+        command.SetAction(parseResult =>
+        {
+            var input = parseResult.GetValue(inputArg)!;
+            var output = parseResult.GetValue(outputOpt)
+                         ?? Path.Combine(Environment.CurrentDirectory, "foscail-out");
+            var convert = parseResult.GetValue(convertOpt);
+
+            return Run(input, output, convert);
+        });
+
+        return command;
+    }
+
+    public static int Run(string input, string output, bool convert)
+    {
+        var archives = ResolveArchives(input);
+
+        if (archives.Count == 0)
+        {
+            Console.Error.WriteLine($"No .dat archive found at '{input}'.");
+            return 1;
+        }
+
+        var totalEntries = 0;
+        var totalImages = 0;
+        var failures = 0;
+
+        foreach (var archivePath in archives)
+        {
+            var fileName = Path.GetFileName(archivePath);
+
+            if (NonArchiveNames.Contains(fileName))
+            {
+                Console.WriteLine($"  {fileName}: skipped (not an asset archive)");
+                continue;
+            }
+
+            var name = Path.GetFileNameWithoutExtension(archivePath);
+            var destDir = Path.Combine(output, name);
+
+            DataArchive archive;
+
+            try
+            {
+                // the extended (obfuscated/zlib) layout can't be parsed yet; report it rather than
+                // letting the legacy parser read its leading 0xFFFFFFFF as an entry count
+                if (IsExtendedFormat(archivePath))
+                {
+                    Console.Error.WriteLine($"  ! {fileName}: extended-format archive is not supported yet");
+                    failures++;
+
+                    continue;
+                }
+
+                Directory.CreateDirectory(destDir);
+                archive = DataArchive.FromFile(archivePath, memoryMapped: true);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"  ! {fileName}: failed to open ({ex.Message})");
+                failures++;
+
+                continue;
+            }
+
+            using (archive)
+            {
+                try
+                {
+                    archive.ExtractTo(destDir);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"  ! {fileName}: extraction failed ({ex.Message})");
+                    failures++;
+
+                    continue;
+                }
+
+                totalEntries += archive.Count;
+                Console.WriteLine($"  {name}: {archive.Count} entries -> {destDir}");
+
+                if (!convert)
+                    continue;
+
+                foreach (var entry in archive)
+                {
+                    try
+                    {
+                        totalImages += AssetConverter.ConvertEntry(entry, destDir);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"    ! {entry.EntryName}: convert failed ({ex.Message})");
+                        failures++;
+                    }
+                }
+            }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"Done. {archives.Count} archive(s), {totalEntries} entries extracted"
+                          + (convert ? $", {totalImages} image(s) converted" : "")
+                          + (failures > 0 ? $", {failures} failure(s)" : "")
+                          + ".");
+
+        return failures > 0 ? 2 : 0;
+    }
+
+    private static List<string> ResolveArchives(string input)
+    {
+        if (Directory.Exists(input))
+            return Directory.EnumerateFiles(input, "*.dat", new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive })
+                            .OrderBy(static p => p, StringComparer.OrdinalIgnoreCase)
+                            .ToList();
+
+        if (File.Exists(input))
+            return [input];
+
+        // allow passing an archive name without the extension
+        if (File.Exists(input + ".dat"))
+            return [input + ".dat"];
+
+        return [];
+    }
+
+    // The extended (obfuscated/zlib) archive layout is signalled by a leading 0xFFFFFFFF word;
+    // everything else is the legacy fixed-index layout.
+    private static bool IsExtendedFormat(string path)
+    {
+        Span<byte> head = stackalloc byte[4];
+
+        using var fs = File.OpenRead(path);
+
+        return fs.ReadAtLeast(head, 4, throwOnEndOfStream: false) == 4
+               && BinaryPrimitives.ReadUInt32LittleEndian(head) == 0xFFFFFFFF;
+    }
+}

--- a/Foscail/Conversion/AssetConverter.cs
+++ b/Foscail/Conversion/AssetConverter.cs
@@ -1,0 +1,94 @@
+using DALib.Data;
+using DALib.Definitions;
+using DALib.Drawing;
+using SkiaSharp;
+
+namespace Foscail.Conversion;
+
+/// <summary>
+///     Converts self-contained image assets to PNG. v1 handles the formats that carry everything
+///     they need to render (SPF embeds its palette or is colorized; EFA is colorized with its own
+///     blend mode). Palette-dependent formats (EPF/MPF/HPF/tiles) need external TBL/PAL resolution
+///     and are left as raw extractions for a later milestone.
+/// </summary>
+internal static class AssetConverter
+{
+    /// <summary>Writes a PNG per renderable frame. Returns the number of images written (0 if unsupported).</summary>
+    public static int ConvertEntry(DataArchiveEntry entry, string destDir)
+    {
+        var ext = Path.GetExtension(entry.EntryName).ToLowerInvariant();
+
+        return ext switch
+        {
+            ".spf" => ConvertSpf(entry, destDir),
+            ".efa" => ConvertEfa(entry, destDir),
+            _      => 0
+        };
+    }
+
+    private static int ConvertSpf(DataArchiveEntry entry, string destDir)
+    {
+        var spf = SpfFile.FromEntry(entry);
+        var written = 0;
+
+        for (var i = 0; i < spf.Count; i++)
+        {
+            var frame = spf[i];
+
+            // Empty placeholder frames carry non-positive (often negative) dimensions and no pixel
+            // data. DALib's EPF/EFA renderers guard this; the SPF overloads don't, so skip here.
+            // Real frames keep their source index in the filename, so gaps are faithful.
+            if (frame.PixelWidth <= 0 || frame.PixelHeight <= 0)
+                continue;
+
+            using var image = spf.Format == SpfFormatType.Colorized
+                ? Graphics.RenderImage(frame)
+                : Graphics.RenderImage(frame, spf.PrimaryColors!);
+
+            WritePng(image, destDir, entry.EntryName, i, spf.Count);
+            written++;
+        }
+
+        return written;
+    }
+
+    private static int ConvertEfa(DataArchiveEntry entry, string destDir)
+    {
+        var efa = EfaFile.FromEntry(entry);
+        var written = 0;
+
+        for (var i = 0; i < efa.Count; i++)
+        {
+            using var image = Graphics.RenderImage(efa[i], efa.BlendingType);
+
+            WritePng(image, destDir, entry.EntryName, i, efa.Count);
+            written++;
+        }
+
+        return written;
+    }
+
+    // Single-frame assets become <name>.png; multi-frame become <name>.000.png, <name>.001.png, ...
+    // The original entry name (extension included) is kept so a converted image never collides with
+    // its raw source or with another format that shares the stem.
+    private static void WritePng(SKImage image, string destDir, string entryName, int frame, int frameCount)
+    {
+        var suffix = frameCount > 1 ? $".{frame:D3}" : string.Empty;
+
+        var destRoot = Path.GetFullPath(destDir);
+
+        if (!Path.EndsInDirectorySeparator(destRoot))
+            destRoot += Path.DirectorySeparatorChar;
+
+        // entry names come from archive bytes; refuse any that would resolve outside the destination
+        var path = Path.GetFullPath($"{entryName}{suffix}.png", destRoot);
+
+        if (!path.StartsWith(destRoot, StringComparison.Ordinal))
+            throw new InvalidDataException($"Entry name \"{entryName}\" resolves outside the output directory");
+
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var fs = File.Create(path);
+
+        data.SaveTo(fs);
+    }
+}

--- a/Foscail/Foscail.csproj
+++ b/Foscail/Foscail.csproj
@@ -20,7 +20,11 @@
         <RepositoryUrl>https://github.com/eriscorp/dalib</RepositoryUrl>
         <Tags>hybrasyl; dalib; foscail; dat; epf; spf; doomvas;</Tags>
         <IsPackable>true</IsPackable>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../DALib/DALib.csproj"/>
     </ItemGroup>

--- a/Foscail/Foscail.csproj
+++ b/Foscail/Foscail.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <LangVersion>14</LangVersion>
+        <RootNamespace>Foscail</RootNamespace>
+        <AssemblyName>foscail</AssemblyName>
+
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>foscail</ToolCommandName>
+        <PackageId>Foscail</PackageId>
+        <Version>1.0.0-beta1</Version>
+        <Title>Foscail</Title>
+        <Description>Command-line tools for Dark Ages (DOOMVAS v1) client data — unpack DAT archives and convert assets to modern formats.</Description>
+        <Authors>Kyle Speck and contributors</Authors>
+        <Copyright>See CONTRIBUTORS.md</Copyright>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/eriscorp/dalib</RepositoryUrl>
+        <Tags>hybrasyl; dalib; foscail; dat; epf; spf; doomvas;</Tags>
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="../DALib/DALib.csproj"/>
+    </ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="Foscail.Tests"/>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="System.CommandLine" Version="2.0.10"/>
+        <!-- SkiaSharp's base package bundles Windows/macOS native assets but not Linux; the tool
+             pulls the self-contained Linux .so so rendering works on headless Linux too. -->
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.0"/>
+    </ItemGroup>
+</Project>

--- a/Foscail/Program.cs
+++ b/Foscail/Program.cs
@@ -1,0 +1,7 @@
+using System.CommandLine;
+using Foscail.Commands;
+
+var root = new RootCommand("Foscail — command-line tools for Dark Ages (DOOMVAS v1) client data.");
+root.Add(UnpackCommand.Build());
+
+return root.Parse(args).Invoke();

--- a/Foscail/README.md
+++ b/Foscail/README.md
@@ -1,0 +1,49 @@
+# foscail
+
+Command-line tools for Dark Ages (DOOMVAS v1) client data, built on
+[DALib](https://github.com/eriscorp/dalib). *Foscail* is Irish for "open."
+
+## Install
+
+```
+dotnet tool install --global Foscail --prerelease
+```
+
+## Usage
+
+```
+foscail unpack <input> [--output <dir>] [--convert]
+```
+
+`<input>` is a `.dat` archive, an archive name without the extension, or a
+directory containing `.dat` archives (matched case-insensitively). Each archive
+is unpacked into its own subdirectory of the output directory (default
+`./foscail-out`).
+
+```
+foscail unpack "C:\Program Files\KRU\Dark Ages" -o ./extracted --convert
+```
+
+With `--convert`, image formats that carry everything they need to render are
+also written as PNG alongside the raw files:
+
+| Format | Contents | Raw extract | PNG conversion |
+|--------|----------|-------------|----------------|
+| SPF    | UI / interface art | yes | yes |
+| EFA    | effect animations  | yes | yes |
+| EPF, HPF, MPF, tiles | sprites, walls, monsters, maps | yes | planned (needs TBL/PAL palette resolution) |
+| everything else (txt, pal, tbl, ...) | | yes | — |
+
+Multi-frame assets become `name.000.png`, `name.001.png`, …; single frames
+become `name.png`. Converted images keep the full original entry name so they
+never collide with their raw source.
+
+## Behavior notes
+
+- A corrupt, hostile, or unreadable archive is reported and counted as a
+  failure; the rest of the batch still processes. Exit code is `0` for a fully
+  clean run, `2` if any failures occurred, `1` if no archive was found.
+- Archives in the extended format (leading `0xFFFFFFFF` word, used by some
+  newer clients) are reported as unsupported rather than mis-parsed.
+- Entry names are validated so a malicious archive cannot write outside the
+  output directory.


### PR DESCRIPTION
## What this adds

**foscail** (Irish, "open") — a `dotnet tool` CLI shipped alongside DALib. `foscail unpack` extracts every entry from one or more DAT archives into per-archive directories; `--convert` additionally renders the self-contained image formats (SPF, EFA) to PNG. Palette-dependent formats (EPF/HPF/MPF/tiles) are raw-extracted for now — TBL/PAL resolution is the next milestone.

Verified against 3.61 and 7.41 client corpora: 20 archives, 55,518 entries, 3,605 PNGs, zero failures.

## Library fixes along the way

- **Empty-frame NRE**: empty SPF placeholder frames (non-positive dimensions, no pixel data) crashed the shared `SimpleRender` helper; the EPF/EFA paths were guarded but the helper wasn't. Fixed centrally — degenerate frames render as 1×1 transparent — with a regression test.
- **`DataArchive` hardening** (from an external Codex review of the tool, all four findings verified against source before fixing):
  - `ExtractTo` canonicalizes each output path and refuses entry names that resolve outside the destination (path traversal via `../x` or rooted names — latent for all DALib consumers, not just foscail)
  - the constructor rejects negative entry-count words (`InvalidDataException`) instead of silently yielding an empty archive when handed the extended `0xFFFFFFFF`-headed layout or other garbage — note this is a small public behavior change
  - `FromFile` honors an existing path as-given; `WithExtension` remains only the extensionless-name convenience (it used to rewrite `FOO.DAT` → `FOO.dat`, which breaks on case-sensitive filesystems)

## Tool robustness (same review)

- extraction runs inside the per-archive failure boundary — one bad archive costs a failure count, not the batch
- extended-format archives are reported as unsupported failures, never silently parsed as empty
- `.dat` discovery is case-insensitive (the 3.61 corpus's own `FILE00XX.DAT` was previously invisible on Linux)
- PNG output paths get the same containment check as extraction

## Tests

New `Foscail.Tests` project drives `UnpackCommand.Run` end-to-end over synthetic archives: happy path, hostile-archive batch continuation, extended-format reporting, uppercase-extension discovery (glob and direct path). New `DataArchiveTests` covers the library guards, including fail-without-fix cases for traversal and the negative-count parse. 940 tests green.

Generated with Imbas <imbas@eris.co>
